### PR TITLE
Fix/horizontal notification panel

### DIFF
--- a/app/src/main/java/com/ekoehler/expressivecutout/data/BehaviourPreferences.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/data/BehaviourPreferences.kt
@@ -51,6 +51,7 @@ enum class AnimationBounce { BIG, NORMAL, SMALL }
 data class BehaviourSettings(
     val cutoutEnabled: Boolean = DEFAULT_CUTOUT_ENABLED,
     val hideOnLockscreen: Boolean = DEFAULT_HIDE_ON_LOCKSCREEN,
+    val hideInLandscape: Boolean = DEFAULT_HIDE_IN_LANDSCAPE,
     val animationStyle: AnimationStyle = DEFAULT_ANIMATION_STYLE,
     val animationSpeed: AnimationSpeed = DEFAULT_ANIMATION_SPEED,
     val animationBounce: AnimationBounce = DEFAULT_ANIMATION_BOUNCE,
@@ -70,6 +71,7 @@ data class BehaviourSettings(
     companion object {
         const val DEFAULT_CUTOUT_ENABLED = true
         const val DEFAULT_HIDE_ON_LOCKSCREEN = false
+        const val DEFAULT_HIDE_IN_LANDSCAPE = false
         // Baseline for the island's primary expand/collapse transition; the reveal, background fade
         // and other animations scale in proportion to it. Matches the tuned defaults in DynamicIsland.
         const val DEFAULT_ANIMATION_DURATION_MS = 220
@@ -103,6 +105,7 @@ class BehaviourPreferences(private val context: Context) {
         BehaviourSettings(
             cutoutEnabled = prefs[CUTOUT_ENABLED] ?: BehaviourSettings.DEFAULT_CUTOUT_ENABLED,
             hideOnLockscreen = prefs[HIDE_ON_LOCKSCREEN] ?: BehaviourSettings.DEFAULT_HIDE_ON_LOCKSCREEN,
+            hideInLandscape = prefs[HIDE_IN_LANDSCAPE] ?: BehaviourSettings.DEFAULT_HIDE_IN_LANDSCAPE,
             animationStyle = prefs[ANIMATION_STYLE]
                 ?.let { runCatching { AnimationStyle.valueOf(it) }.getOrNull() }
                 ?: BehaviourSettings.DEFAULT_ANIMATION_STYLE,
@@ -140,6 +143,10 @@ class BehaviourPreferences(private val context: Context) {
 
     suspend fun setHideOnLockscreen(enabled: Boolean) = context.behaviourDataStore.edit {
         it[HIDE_ON_LOCKSCREEN] = enabled
+    }
+
+    suspend fun setHideInLandscape(enabled: Boolean) = context.behaviourDataStore.edit {
+        it[HIDE_IN_LANDSCAPE] = enabled
     }
 
     suspend fun setAnimationStyle(style: AnimationStyle) = context.behaviourDataStore.edit {
@@ -214,6 +221,7 @@ class BehaviourPreferences(private val context: Context) {
     private companion object {
         val CUTOUT_ENABLED = booleanPreferencesKey("cutout_enabled")
         val HIDE_ON_LOCKSCREEN = booleanPreferencesKey("hide_on_lockscreen")
+        val HIDE_IN_LANDSCAPE = booleanPreferencesKey("hide_in_landscape")
         val ANIMATION_STYLE = stringPreferencesKey("animation_style")
         val ANIMATION_SPEED = stringPreferencesKey("animation_speed")
         val ANIMATION_BOUNCE = stringPreferencesKey("animation_bounce")

--- a/app/src/main/java/com/ekoehler/expressivecutout/data/BehaviourPreferences.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/data/BehaviourPreferences.kt
@@ -13,6 +13,9 @@ import kotlinx.coroutines.flow.map
 
 private val Context.behaviourDataStore: DataStore<Preferences> by preferencesDataStore(name = "behaviour_prefs")
 
+/** How the cutout behaves when the device is in horizontal/landscape orientation. */
+enum class HorizontalCutoutMode { HIDDEN, NORMAL_ONLY, STICK_TO_CAMERA, CENTER }
+
 /** Which horizontal swipe directions dismiss the cutout, when swipe-to-dismiss is enabled. */
 enum class SwipeDismissDirection { LEFT, RIGHT, BOTH }
 
@@ -52,6 +55,7 @@ data class BehaviourSettings(
     val cutoutEnabled: Boolean = DEFAULT_CUTOUT_ENABLED,
     val hideOnLockscreen: Boolean = DEFAULT_HIDE_ON_LOCKSCREEN,
     val hideInLandscape: Boolean = DEFAULT_HIDE_IN_LANDSCAPE,
+    val horizontalCutoutMode: HorizontalCutoutMode = DEFAULT_HORIZONTAL_CUTOUT_MODE,
     val animationStyle: AnimationStyle = DEFAULT_ANIMATION_STYLE,
     val animationSpeed: AnimationSpeed = DEFAULT_ANIMATION_SPEED,
     val animationBounce: AnimationBounce = DEFAULT_ANIMATION_BOUNCE,
@@ -72,6 +76,7 @@ data class BehaviourSettings(
         const val DEFAULT_CUTOUT_ENABLED = true
         const val DEFAULT_HIDE_ON_LOCKSCREEN = false
         const val DEFAULT_HIDE_IN_LANDSCAPE = false
+        val DEFAULT_HORIZONTAL_CUTOUT_MODE = HorizontalCutoutMode.CENTER
         // Baseline for the island's primary expand/collapse transition; the reveal, background fade
         // and other animations scale in proportion to it. Matches the tuned defaults in DynamicIsland.
         const val DEFAULT_ANIMATION_DURATION_MS = 220
@@ -102,10 +107,21 @@ data class BehaviourSettings(
 class BehaviourPreferences(private val context: Context) {
 
     val settings: Flow<BehaviourSettings> = context.behaviourDataStore.data.map { prefs ->
+        val rawMode = prefs[HORIZONTAL_CUTOUT_MODE]
+        val hideLandscape = prefs[HIDE_IN_LANDSCAPE] ?: BehaviourSettings.DEFAULT_HIDE_IN_LANDSCAPE
+        val horizontalCutoutMode = if (rawMode != null) {
+            runCatching { HorizontalCutoutMode.valueOf(rawMode) }.getOrDefault(BehaviourSettings.DEFAULT_HORIZONTAL_CUTOUT_MODE)
+        } else if (hideLandscape) {
+            HorizontalCutoutMode.HIDDEN
+        } else {
+            BehaviourSettings.DEFAULT_HORIZONTAL_CUTOUT_MODE
+        }
+
         BehaviourSettings(
             cutoutEnabled = prefs[CUTOUT_ENABLED] ?: BehaviourSettings.DEFAULT_CUTOUT_ENABLED,
             hideOnLockscreen = prefs[HIDE_ON_LOCKSCREEN] ?: BehaviourSettings.DEFAULT_HIDE_ON_LOCKSCREEN,
-            hideInLandscape = prefs[HIDE_IN_LANDSCAPE] ?: BehaviourSettings.DEFAULT_HIDE_IN_LANDSCAPE,
+            hideInLandscape = hideLandscape || (horizontalCutoutMode == HorizontalCutoutMode.HIDDEN),
+            horizontalCutoutMode = horizontalCutoutMode,
             animationStyle = prefs[ANIMATION_STYLE]
                 ?.let { runCatching { AnimationStyle.valueOf(it) }.getOrNull() }
                 ?: BehaviourSettings.DEFAULT_ANIMATION_STYLE,
@@ -147,6 +163,14 @@ class BehaviourPreferences(private val context: Context) {
 
     suspend fun setHideInLandscape(enabled: Boolean) = context.behaviourDataStore.edit {
         it[HIDE_IN_LANDSCAPE] = enabled
+        if (enabled) {
+            it[HORIZONTAL_CUTOUT_MODE] = HorizontalCutoutMode.HIDDEN.name
+        }
+    }
+
+    suspend fun setHorizontalCutoutMode(mode: HorizontalCutoutMode) = context.behaviourDataStore.edit {
+        it[HORIZONTAL_CUTOUT_MODE] = mode.name
+        it[HIDE_IN_LANDSCAPE] = (mode == HorizontalCutoutMode.HIDDEN)
     }
 
     suspend fun setAnimationStyle(style: AnimationStyle) = context.behaviourDataStore.edit {
@@ -222,6 +246,7 @@ class BehaviourPreferences(private val context: Context) {
         val CUTOUT_ENABLED = booleanPreferencesKey("cutout_enabled")
         val HIDE_ON_LOCKSCREEN = booleanPreferencesKey("hide_on_lockscreen")
         val HIDE_IN_LANDSCAPE = booleanPreferencesKey("hide_in_landscape")
+        val HORIZONTAL_CUTOUT_MODE = stringPreferencesKey("horizontal_cutout_mode")
         val ANIMATION_STYLE = stringPreferencesKey("animation_style")
         val ANIMATION_SPEED = stringPreferencesKey("animation_speed")
         val ANIMATION_BOUNCE = stringPreferencesKey("animation_bounce")

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
@@ -343,7 +343,7 @@ fun DynamicIsland(
         spec, label = "islandWidth"
     )
     val height by animateDpAsState(
-        if (isStickToCamera) (collapsed.heightDp * 2.2f).dp else (dims.heightDp + heightBonus).dp,
+        if (isStickToCamera) (displayWidthDp * dims.widthPercent / 100f).dp else (dims.heightDp + heightBonus).dp,
         spec, label = "islandHeight"
     )
     val cornerRadius = (collapsed.heightDp / 2f).dp

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
@@ -205,6 +205,9 @@ fun DynamicIsland(
     expanded: IslandDimensions,
     displayWidthDp: Int,
     forcedExpanded: Boolean?,
+    isStickToCamera: Boolean = false,
+    isRotation270: Boolean = false,
+    offsetYDp: Int = 6,
     animationStyle: AnimationStyle,
     animationSpeed: AnimationSpeed,
     animationBounce: AnimationBounce,
@@ -230,8 +233,8 @@ fun DynamicIsland(
     }
     val shownEvent = lastEvent
 
-    // Keyed on the shown event so tapping persists during that event and resets for a new one.
-    var tapExpanded by remember(shownEvent?.id) { mutableStateOf(shownEvent?.initiallyExpanded ?: false) }
+    val initialExpandedState = if (forcedExpanded == false) false else (shownEvent?.initiallyExpanded ?: false)
+    var tapExpanded by remember(shownEvent?.id, forcedExpanded) { mutableStateOf(initialExpandedState) }
     // The reply action currently being typed for, if any. Reset when the event changes.
     var replyingTo by remember(shownEvent?.id) { mutableStateOf<IslandAction?>(null) }
     val replying = replyingTo != null
@@ -242,7 +245,7 @@ fun DynamicIsland(
     // The phone tile has no expanded state: it is shown as one bigger "normal" cutout, so tapping
     // never expands it and its size never switches to the expanded dimensions.
     val isCall = shownEvent?.call != null
-    val isExpanded = if (isCall) false else (forcedExpanded ?: tapExpanded)
+    val isExpanded = if (isCall || forcedExpanded == false) false else (forcedExpanded ?: tapExpanded)
     val boopScale = remember { Animatable(1f) }
     // Horizontal drag offset for swipe-to-dismiss; reset for each new event so a fresh pill starts centred.
     val dismissOffsetX = remember(shownEvent?.id) { Animatable(0f) }
@@ -335,14 +338,21 @@ fun DynamicIsland(
     // next state instead of animating: a cutout dismissed while expanded resets to its normal height
     // off-screen, so the next appearance grows from the dot at the right height with no catch-up lag.
     val spec: AnimationSpec<Dp> = if (reveal.value == 0f) snap() else motion.dp()
-    val width by animateDpAsState((displayWidthDp * dims.widthPercent / 100f).dp, spec, label = "islandWidth")
-    val height by animateDpAsState((dims.heightDp + heightBonus).dp, spec, label = "islandHeight")
-    val offsetX by animateDpAsState(dims.offsetXDp.dp, spec, label = "islandOffsetX")
-    val offsetY by animateDpAsState(dims.offsetYDp.dp, spec, label = "islandOffsetY")
-    val topLeft by animateDpAsState(dims.cornerTopLeftDp.dp, spec, label = "cornerTL")
-    val topRight by animateDpAsState(dims.cornerTopRightDp.dp, spec, label = "cornerTR")
-    val bottomLeft by animateDpAsState(dims.cornerBottomLeftDp.dp, spec, label = "cornerBL")
-    val bottomRight by animateDpAsState(dims.cornerBottomRightDp.dp, spec, label = "cornerBR")
+    val width by animateDpAsState(
+        if (isStickToCamera) collapsed.heightDp.dp else (displayWidthDp * dims.widthPercent / 100f).dp,
+        spec, label = "islandWidth"
+    )
+    val height by animateDpAsState(
+        if (isStickToCamera) (collapsed.heightDp * 2.2f).dp else (dims.heightDp + heightBonus).dp,
+        spec, label = "islandHeight"
+    )
+    val cornerRadius = (collapsed.heightDp / 2f).dp
+    val offsetX by animateDpAsState(if (isStickToCamera) 0.dp else dims.offsetXDp.dp, spec, label = "islandOffsetX")
+    val offsetY by animateDpAsState(if (isStickToCamera) 0.dp else dims.offsetYDp.dp, spec, label = "islandOffsetY")
+    val topLeft by animateDpAsState(if (isStickToCamera) cornerRadius else dims.cornerTopLeftDp.dp, spec, label = "cornerTL")
+    val topRight by animateDpAsState(if (isStickToCamera) cornerRadius else dims.cornerTopRightDp.dp, spec, label = "cornerTR")
+    val bottomLeft by animateDpAsState(if (isStickToCamera) cornerRadius else dims.cornerBottomLeftDp.dp, spec, label = "cornerBL")
+    val bottomRight by animateDpAsState(if (isStickToCamera) cornerRadius else dims.cornerBottomRightDp.dp, spec, label = "cornerBR")
     // Drives the background cross-fade between the normal and expanded fills, in step with the size.
     val expandProgress by animateFloatAsState(
         targetValue = if (isExpanded) 1f else 0f,
@@ -363,11 +373,16 @@ fun DynamicIsland(
     val revealBottomRight = lerpDp(dotCorner, bottomRight, reveal.value)
 
     Box(modifier = Modifier.fillMaxSize()) {
+        val stickAlignment = if (isRotation270) Alignment.CenterEnd else Alignment.CenterStart
+        val stickPaddingStart = if (isStickToCamera && !isRotation270) offsetYDp.dp else 0.dp
+        val stickPaddingEnd = if (isStickToCamera && isRotation270) offsetYDp.dp else 0.dp
+
         // Position the island in the full-size (non-clipping) window; then animate visibility.
         Box(
             modifier = Modifier
-                .align(Alignment.TopCenter)
-                .offset(x = offsetX, y = offsetY),
+                .align(if (isStickToCamera) stickAlignment else Alignment.TopCenter)
+                .padding(start = stickPaddingStart, end = stickPaddingEnd)
+                .offset(x = if (isStickToCamera) 0.dp else offsetX, y = if (isStickToCamera) 0.dp else offsetY),
         ) {
             // Keep rendering through the exit (until `reveal` reaches 0) so the shrink-back animates.
             if (present || reveal.value > 0f) {
@@ -386,7 +401,7 @@ fun DynamicIsland(
                             alpha = (1f - travel).coerceIn(0.25f, 1f) * revealAlpha
                         }
                         .pointerInput(forcedExpanded, isExpanded, replying, shownEvent?.id) {
-                            if (forcedExpanded != null) return@pointerInput
+                            if (forcedExpanded == true) return@pointerInput
                             detectTapGestures {
                                 // While typing a reply, ignore taps on the surface itself.
                                 if (replying) return@detectTapGestures
@@ -396,11 +411,10 @@ fun DynamicIsland(
                                     if (shownEvent?.contentIntent != null) onActivate()
                                     return@detectTapGestures
                                 }
-                                // Once expanded, tapping a notification opens its app (like tapping
-                                // the real notification); anything else just toggles expand/collapse.
-                                if (isExpanded && shownEvent?.contentIntent != null) {
+                                // Once expanded, or in normal-only mode (forcedExpanded == false), tapping a notification opens its app.
+                                if ((isExpanded || forcedExpanded == false) && shownEvent?.contentIntent != null) {
                                     onActivate()
-                                } else {
+                                } else if (forcedExpanded == null) {
                                     tapExpanded = !tapExpanded
                                     scope.launch {
                                         boopScale.animateTo(1.02f, tween(durationMillis = scaled(120), easing = EmphasizedEasing))
@@ -503,7 +517,7 @@ fun DynamicIsland(
                                     },
                                 )
                             } else {
-                                CollapsedContent(e, collapsed.heightDp)
+                                CollapsedContent(e, collapsed.heightDp, isStickToCamera)
                             }
                         }
                     }
@@ -650,7 +664,7 @@ private fun albumArtStrokeFor(event: IslandEvent): Color? =
         ?.let { it.albumArtStrokeColor?.resolve() ?: event.accent }
 
 @Composable
-private fun CollapsedContent(event: IslandEvent, heightDp: Int) {
+private fun CollapsedContent(event: IslandEvent, heightDp: Int, isStickToCamera: Boolean = false) {
     // The music tile shows album art, the phone tile the caller's photo, on the normal cutout.
     val nowPlaying by NowPlayingBus.state.collectAsStateWithLifecycle()
     val onCall by OnCallBus.state.collectAsStateWithLifecycle()
@@ -660,8 +674,11 @@ private fun CollapsedContent(event: IslandEvent, heightDp: Int) {
 
     Box(modifier = Modifier.fillMaxSize()) {
         val placement = Modifier
-            .align(Alignment.CenterStart)
-            .padding(start = (heightDp * 0.16f).dp)
+            .align(if (isStickToCamera) Alignment.BottomCenter else Alignment.CenterStart)
+            .padding(
+                start = if (isStickToCamera) 0.dp else (heightDp * 0.16f).dp,
+                bottom = if (isStickToCamera) (heightDp * 0.14f).dp else 0.dp,
+            )
         when {
             albumArt != null -> AlbumArt(
                 bitmap = albumArt,
@@ -682,7 +699,7 @@ private fun CollapsedContent(event: IslandEvent, heightDp: Int) {
             )
         }
         // The timer tile shows the remaining time on the trailing edge, opposite its icon.
-        if (event.timer != null) {
+        if (event.timer != null && !isStickToCamera) {
             timerRemainingText()?.let { remaining ->
                 Text(
                     text = remaining,

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
@@ -777,7 +777,7 @@ class IslandOverlayController(private val context: Context) {
         val isStickToCamera = orientationState.value == Configuration.ORIENTATION_LANDSCAPE &&
             behaviourState.value.horizontalCutoutMode == HorizontalCutoutMode.STICK_TO_CAMERA
         if (isStickToCamera) {
-            val islandLengthDp = (layout.collapsed.heightDp * 2.2f).toInt()
+            val islandLengthDp = displayWidthDp.value * (layout.collapsed.widthPercent / 100f)
             return ((islandLengthDp + TOUCH_MARGIN_DP * 2) * density).toInt()
         }
         val collapsed = layout.collapsed
@@ -795,7 +795,7 @@ class IslandOverlayController(private val context: Context) {
             behaviourState.value.horizontalCutoutMode == HorizontalCutoutMode.STICK_TO_CAMERA
         val dims = effectiveDims(layout, expanded)
         if (isStickToCamera) {
-            val islandLengthDp = (dims.heightDp * 2.2f).toInt()
+            val islandLengthDp = displayWidthDp.value * (dims.widthPercent / 100f)
             return ((islandLengthDp + TOUCH_MARGIN_DP * 2) * density).toInt()
         }
         val bonus = currentHeightBonusDp(expanded)

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
@@ -23,6 +23,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
@@ -44,6 +47,7 @@ import com.ekoehler.expressivecutout.data.AppearancePreferences
 import com.ekoehler.expressivecutout.data.AppearanceSettings
 import com.ekoehler.expressivecutout.data.BehaviourPreferences
 import com.ekoehler.expressivecutout.data.BehaviourSettings
+import com.ekoehler.expressivecutout.data.HorizontalCutoutMode
 import com.ekoehler.expressivecutout.data.CutoutColor
 import com.ekoehler.expressivecutout.data.DynamicRole
 import com.ekoehler.expressivecutout.data.DynamicTilePreferences
@@ -122,6 +126,7 @@ class IslandOverlayController(private val context: Context) {
     // an actual portrait <-> landscape flip. Also the single source of truth for the current
     // orientation, ready for orientation-specific layout settings later.
     private var currentOrientation: Int = context.resources.configuration.orientation
+    private val orientationState = MutableStateFlow(currentOrientation)
 
     private val currentEvent = MutableStateFlow<IslandEvent?>(null)
     private val layoutState = MutableStateFlow(IslandLayout.DEFAULT)
@@ -190,6 +195,7 @@ class IslandOverlayController(private val context: Context) {
     // True while the window has been torn down because "hide on lockscreen" or "hide in landscape" is active.
     // Guards signal handling and drives whether the window currently exists.
     private var overlayHidden = false
+    private var savedEventBeforeHide: IslandEvent? = null
 
     // Re-evaluate lock visibility whenever the screen or lock state changes. All are protected
     // system broadcasts.
@@ -255,7 +261,9 @@ class IslandOverlayController(private val context: Context) {
     private fun applyLockVisibility() {
         val shouldHideLock = behaviourState.value.hideOnLockscreen &&
             keyguardManager?.isKeyguardLocked == true
-        val shouldHideLandscape = behaviourState.value.hideInLandscape &&
+        val isLandscapeHidden = behaviourState.value.horizontalCutoutMode == HorizontalCutoutMode.HIDDEN ||
+            behaviourState.value.hideInLandscape
+        val shouldHideLandscape = isLandscapeHidden &&
             currentOrientation == Configuration.ORIENTATION_LANDSCAPE
         val shouldHide = shouldHideLock || shouldHideLandscape
 
@@ -264,6 +272,9 @@ class IslandOverlayController(private val context: Context) {
                 overlayHidden = true
                 dismissJob?.cancel()
                 windowResizeJob?.cancel()
+                if (currentEvent.value != null) {
+                    savedEventBeforeHide = currentEvent.value
+                }
                 currentEvent.value = null
                 removeOverlay()
             }
@@ -272,6 +283,37 @@ class IslandOverlayController(private val context: Context) {
                 overlayHidden = false
                 addOverlay()
                 syncWindowSize()
+                restoreActiveState()
+            }
+        }
+    }
+
+    private fun restoreActiveState() {
+        when {
+            previewPinned -> {
+                dismissJob?.cancel()
+                forcedExpanded.value = previewExpanded
+                expanded = previewExpanded
+                currentEvent.value = previewEvent
+            }
+            callActive && lastCallEvent != null -> {
+                dismissJob?.cancel()
+                expanded = false
+                currentEvent.value = lastCallEvent
+            }
+            musicPlaying && lastMusicEvent != null && !playerAppHidden -> {
+                dismissJob?.cancel()
+                currentEvent.value = lastMusicEvent
+            }
+            timerActive && lastTimerEvent != null -> {
+                dismissJob?.cancel()
+                currentEvent.value = lastTimerEvent
+            }
+            savedEventBeforeHide != null -> {
+                dismissJob?.cancel()
+                currentEvent.value = savedEventBeforeHide
+                savedEventBeforeHide = null
+                scheduleDismiss()
             }
         }
     }
@@ -310,6 +352,7 @@ class IslandOverlayController(private val context: Context) {
     fun onOrientationChanged(orientation: Int) {
         if (orientation == currentOrientation) return
         currentOrientation = orientation
+        orientationState.value = orientation
         displayWidthPx = computeDisplayWidthPx()
         displayWidthDp.value = (displayWidthPx / density).toInt()
         applyLockVisibility()
@@ -329,6 +372,15 @@ class IslandOverlayController(private val context: Context) {
                 val behaviour by behaviourState.collectAsStateWithLifecycle()
                 val appearance by appearanceState.collectAsStateWithLifecycle()
                 val widthDp by displayWidthDp.collectAsStateWithLifecycle()
+                val orientation by orientationState.collectAsStateWithLifecycle()
+                val isNoExpandLandscape = orientation == Configuration.ORIENTATION_LANDSCAPE &&
+                    (behaviour.horizontalCutoutMode == HorizontalCutoutMode.NORMAL_ONLY ||
+                     behaviour.horizontalCutoutMode == HorizontalCutoutMode.STICK_TO_CAMERA)
+                val effectiveForced = if (isNoExpandLandscape) false else forced
+                val isStickToCamera = orientation == Configuration.ORIENTATION_LANDSCAPE &&
+                    behaviour.horizontalCutoutMode == HorizontalCutoutMode.STICK_TO_CAMERA
+                val rot270 = isRotation270()
+
                 // Theme the overlay so the "Dynamic color for all events" badge picks up the app's
                 // real primary / on-primary (Material You or the brand fallback), not the M3 baseline.
                 ExpressiveCutoutTheme {
@@ -337,7 +389,10 @@ class IslandOverlayController(private val context: Context) {
                         collapsed = layout.collapsed,
                         expanded = layout.expanded,
                         displayWidthDp = widthDp,
-                        forcedExpanded = forced,
+                        forcedExpanded = effectiveForced,
+                        isStickToCamera = isStickToCamera,
+                        isRotation270 = rot270,
+                        offsetYDp = layout.collapsed.offsetYDp,
                         animationStyle = behaviour.animationStyle,
                         animationSpeed = behaviour.animationSpeed,
                         animationBounce = behaviour.animationBounce,
@@ -630,9 +685,11 @@ class IslandOverlayController(private val context: Context) {
     private fun resizeWindow(targetWidthPx: Int, targetHeightPx: Int) {
         val view = composeView ?: return
         val params = layoutParams ?: return
-        if (params.width != targetWidthPx || params.height != targetHeightPx) {
+        val targetGravity = computeWindowGravity()
+        if (params.width != targetWidthPx || params.height != targetHeightPx || params.gravity != targetGravity) {
             params.width = targetWidthPx
             params.height = targetHeightPx
+            params.gravity = targetGravity
             runCatching { windowManager.updateViewLayout(view, params) }
         }
     }
@@ -695,6 +752,11 @@ class IslandOverlayController(private val context: Context) {
      * so the rounded edges, drop shadow and tap "boop" scale all stay comfortably tappable.
      */
     private fun pillTouchRect(viewWidth: Int, viewHeight: Int): Rect {
+        val isStickToCamera = orientationState.value == Configuration.ORIENTATION_LANDSCAPE &&
+            behaviourState.value.horizontalCutoutMode == HorizontalCutoutMode.STICK_TO_CAMERA
+        if (isStickToCamera) {
+            return Rect(0, 0, viewWidth, viewHeight)
+        }
         val dims = effectiveDims(layoutState.value, expanded)
         val bonusDp = currentHeightBonusDp(expanded)
         val pillWidthPx = displayWidthPx * dims.widthPercent / 100
@@ -712,6 +774,12 @@ class IslandOverlayController(private val context: Context) {
 
     /** Tall enough for whichever state extends lowest — used for the initial, safe window size. */
     private fun windowHeightPx(layout: IslandLayout): Int {
+        val isStickToCamera = orientationState.value == Configuration.ORIENTATION_LANDSCAPE &&
+            behaviourState.value.horizontalCutoutMode == HorizontalCutoutMode.STICK_TO_CAMERA
+        if (isStickToCamera) {
+            val islandLengthDp = (layout.collapsed.heightDp * 2.2f).toInt()
+            return ((islandLengthDp + TOUCH_MARGIN_DP * 2) * density).toInt()
+        }
         val collapsed = layout.collapsed
         val expanded = layout.expanded
         val lowestDp = maxOf(
@@ -723,7 +791,13 @@ class IslandOverlayController(private val context: Context) {
 
     /** Height needed to contain just one state's pill (plus room for action chips when expanded). */
     private fun windowHeightPx(layout: IslandLayout, expanded: Boolean): Int {
+        val isStickToCamera = orientationState.value == Configuration.ORIENTATION_LANDSCAPE &&
+            behaviourState.value.horizontalCutoutMode == HorizontalCutoutMode.STICK_TO_CAMERA
         val dims = effectiveDims(layout, expanded)
+        if (isStickToCamera) {
+            val islandLengthDp = (dims.heightDp * 2.2f).toInt()
+            return ((islandLengthDp + TOUCH_MARGIN_DP * 2) * density).toInt()
+        }
         val bonus = currentHeightBonusDp(expanded)
         return ((dims.offsetYDp + dims.heightDp + bonus + WINDOW_MARGIN_DP) * density).toInt()
     }
@@ -739,11 +813,15 @@ class IslandOverlayController(private val context: Context) {
      * whole screen) is what lets the notification shade be pulled from beside the pill in landscape.
      */
     private fun windowWidthPx(layout: IslandLayout, expanded: Boolean): Int {
+        val isStickToCamera = orientationState.value == Configuration.ORIENTATION_LANDSCAPE &&
+            behaviourState.value.horizontalCutoutMode == HorizontalCutoutMode.STICK_TO_CAMERA
         val dims = effectiveDims(layout, expanded)
-        val pillWidthPx = displayWidthPx * dims.widthPercent / 100
-        val offsetXPx = (abs(dims.offsetXDp) * density).toInt()
-        val marginPx = (WINDOW_MARGIN_DP * density).toInt()
-        return (pillWidthPx + 2 * (offsetXPx + marginPx)).coerceAtMost(displayWidthPx)
+        if (isStickToCamera) {
+            val totalDp = dims.offsetYDp + dims.heightDp + TOUCH_MARGIN_DP * 2
+            return (totalDp * density).toInt()
+        }
+        val islandWidthDp = displayWidthDp.value * (dims.widthPercent / 100f)
+        return ((islandWidthDp + WINDOW_MARGIN_DP * 2) * density).toInt()
     }
 
     /**
@@ -818,13 +896,17 @@ class IslandOverlayController(private val context: Context) {
             .collect { (pinned, expandedTab) ->
                 previewPinned = pinned
                 previewExpanded = expandedTab
+                val isNoExpandLandscape = currentOrientation == Configuration.ORIENTATION_LANDSCAPE &&
+                    (behaviourState.value.horizontalCutoutMode == HorizontalCutoutMode.NORMAL_ONLY ||
+                     behaviourState.value.horizontalCutoutMode == HorizontalCutoutMode.STICK_TO_CAMERA)
+                val targetExpanded = if (isNoExpandLandscape) false else expandedTab
                 if (pinned) {
                     dismissJob?.cancel()
-                    forcedExpanded.value = expandedTab
-                    expanded = expandedTab
+                    forcedExpanded.value = targetExpanded
+                    expanded = targetExpanded
                     currentEvent.value = previewEvent
                 } else {
-                    forcedExpanded.value = null
+                    forcedExpanded.value = if (isNoExpandLandscape) false else null
                     expanded = false
                     currentEvent.value = null
                 }
@@ -834,10 +916,6 @@ class IslandOverlayController(private val context: Context) {
 
     private fun observeSignals() = scope.launch {
         IslandEventBus.signals.collect { signal ->
-            // Window is torn down for lockscreen/landscape — drop signals so nothing is queued behind it.
-            if (overlayHidden) return@collect
-            // Master switch: nothing shows when the cutout is disabled.
-            if (!behaviourState.value.cutoutEnabled) return@collect
             // Skip system events the user disabled for the pill.
             if (signal is CutoutSignal.System && eventEnabled[signal.type] == false) return@collect
             // Skip now-playing media when the music tile is turned off.
@@ -847,9 +925,11 @@ class IslandOverlayController(private val context: Context) {
             // Skip the running timer when the timer tile is turned off.
             if (signal is CutoutSignal.Timer && tileEnabled[DynamicTile.TIMER] == false) return@collect
 
-            // Expand for a notification (when configured) or the music / phone tile, so its details
-            // show. The timer rests collapsed — it is the countdown pill; a tap opens its controls.
-            val autoExpand = when (signal) {
+            val isNoExpandLandscape = currentOrientation == Configuration.ORIENTATION_LANDSCAPE &&
+                (behaviourState.value.horizontalCutoutMode == HorizontalCutoutMode.NORMAL_ONLY ||
+                 behaviourState.value.horizontalCutoutMode == HorizontalCutoutMode.STICK_TO_CAMERA)
+
+            val rawAutoExpand = when (signal) {
                 is CutoutSignal.Notification -> behaviourState.value.notificationsAutoExpand
                 is CutoutSignal.Music -> musicSettings.expandOnPlay
                 // The phone tile has no expanded state — it is shown as one bigger normal cutout.
@@ -857,11 +937,9 @@ class IslandOverlayController(private val context: Context) {
                 is CutoutSignal.Timer -> false
                 is CutoutSignal.System -> false
             }
-            // Remember the system event (if any) so its auto-dismiss honours its per-event duration.
-            currentSystemEventType = (signal as? CutoutSignal.System)?.type
-            forcedExpanded.value = null
-            expanded = autoExpand
-            currentEvent.value = resolver.resolve(
+            val autoExpand = if (isNoExpandLandscape) false else rawAutoExpand
+
+            val resolvedEvent = resolver.resolve(
                 signal,
                 customIcons,
                 musicSettings,
@@ -874,25 +952,55 @@ class IslandOverlayController(private val context: Context) {
                 eventAnimatedIconLoops,
                 eventColors,
             ).copy(initiallyExpanded = autoExpand)
+
+            if (overlayHidden) {
+                if (behaviourState.value.cutoutEnabled) {
+                    savedEventBeforeHide = resolvedEvent
+                    when (signal) {
+                        is CutoutSignal.Music -> {
+                            musicPlaying = true
+                            lastMusicEvent = resolvedEvent
+                        }
+                        is CutoutSignal.Call -> {
+                            callActive = true
+                            lastCallEvent = resolvedEvent
+                        }
+                        is CutoutSignal.Timer -> {
+                            timerActive = true
+                            lastTimerEvent = resolvedEvent
+                        }
+                        else -> {}
+                    }
+                }
+                return@collect
+            }
+
+            if (!behaviourState.value.cutoutEnabled) return@collect
+
+            // Remember the system event (if any) so its auto-dismiss honours its per-event duration.
+            currentSystemEventType = (signal as? CutoutSignal.System)?.type
+            forcedExpanded.value = if (isNoExpandLandscape) false else null
+            expanded = autoExpand
+            currentEvent.value = resolvedEvent
             syncWindowSize()
             // A music/call signal is only emitted while that tile is live, so pin it up rather than
             // starting the auto-dismiss timer — it stays for as long as playback / the call lasts.
             when (signal) {
                 is CutoutSignal.Music -> {
                     musicPlaying = true
-                    lastMusicEvent = currentEvent.value
+                    lastMusicEvent = resolvedEvent
                     dismissJob?.cancel()
                 }
 
                 is CutoutSignal.Call -> {
                     callActive = true
-                    lastCallEvent = currentEvent.value
+                    lastCallEvent = resolvedEvent
                     dismissJob?.cancel()
                 }
 
                 is CutoutSignal.Timer -> {
                     timerActive = true
-                    lastTimerEvent = currentEvent.value
+                    lastTimerEvent = resolvedEvent
                     dismissJob?.cancel()
                 }
 
@@ -903,21 +1011,23 @@ class IslandOverlayController(private val context: Context) {
             // returns via musicPillToReturnTo() once the user leaves that app.
             if (signal is CutoutSignal.Music && shouldHideForPlayerApp()) {
                 playerAppHidden = true
-                forcedExpanded.value = null
-                expanded = false
                 currentEvent.value = null
-                syncWindowSize()
+                removeOverlay()
             }
         }
     }
 
     /** Pause auto-dismiss while expanded; on collapse either hide or return to the normal cutout. */
     private fun onExpandedChanged(isExpanded: Boolean) {
+        val isNoExpandLandscape = currentOrientation == Configuration.ORIENTATION_LANDSCAPE &&
+            (behaviourState.value.horizontalCutoutMode == HorizontalCutoutMode.NORMAL_ONLY ||
+             behaviourState.value.horizontalCutoutMode == HorizontalCutoutMode.STICK_TO_CAMERA)
+        val targetExpanded = if (isNoExpandLandscape) false else isExpanded
         val wasExpanded = expanded
-        expanded = isExpanded
+        expanded = targetExpanded
         syncWindowSize()
         when {
-            isExpanded -> dismissJob?.cancel()
+            targetExpanded -> dismissJob?.cancel()
             previewPinned -> Unit
             // While music plays or a call is live, keep the collapsed pill up instead of dismissing.
             isPinnedLiveTile() -> dismissJob?.cancel()
@@ -1122,6 +1232,46 @@ class IslandOverlayController(private val context: Context) {
         }
     }
 
+    private fun computeWindowGravity(): Int {
+        if (currentOrientation != Configuration.ORIENTATION_LANDSCAPE) {
+            return Gravity.TOP or Gravity.CENTER_HORIZONTAL
+        }
+        return when (behaviourState.value.horizontalCutoutMode) {
+            HorizontalCutoutMode.STICK_TO_CAMERA -> getLandscapeCameraGravity()
+            else -> Gravity.TOP or Gravity.CENTER_HORIZONTAL
+        }
+    }
+
+    private fun isRotation270(): Boolean {
+        @Suppress("DEPRECATION")
+        val display = windowManager.defaultDisplay
+        return display?.rotation == android.view.Surface.ROTATION_270
+    }
+
+    private fun getLandscapeCameraGravity(): Int {
+        @Suppress("DEPRECATION")
+        val display = windowManager.defaultDisplay
+        return when (display?.rotation) {
+            android.view.Surface.ROTATION_90 -> Gravity.LEFT or Gravity.CENTER_VERTICAL
+            android.view.Surface.ROTATION_270 -> Gravity.RIGHT or Gravity.CENTER_VERTICAL
+            else -> Gravity.LEFT or Gravity.CENTER_VERTICAL
+        }
+    }
+
+    private fun getLandscapeCameraRotation(): Float {
+        val display = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            context.display
+        } else {
+            @Suppress("DEPRECATION")
+            windowManager.defaultDisplay
+        }
+        return when (display?.rotation) {
+            android.view.Surface.ROTATION_90 -> 90f
+            android.view.Surface.ROTATION_270 -> -90f
+            else -> 0f
+        }
+    }
+
     private fun buildLayoutParams(): WindowManager.LayoutParams {
         @Suppress("DEPRECATION")
         val overlayType = WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY
@@ -1139,7 +1289,7 @@ class IslandOverlayController(private val context: Context) {
                 WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
             PixelFormat.TRANSLUCENT,
         ).apply {
-            gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
+            gravity = computeWindowGravity()
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 layoutInDisplayCutoutMode =
                     WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
@@ -8,6 +8,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.res.Configuration
 import android.graphics.PixelFormat
 import android.graphics.Rect
 import android.graphics.Region
@@ -71,6 +72,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import java.lang.reflect.Proxy
+import kotlin.math.abs
 
 /**
  * Owns the single overlay window and drives it from the [IslandEventBus]. Created and
@@ -107,15 +109,19 @@ class IslandOverlayController(private val context: Context) {
     private val timerTilePreferences = TimerTilePreferences(context)
     private val density = context.resources.displayMetrics.density
 
-    // Full display width, used by the island to size itself as a percentage of the screen.
-    private val displayWidthPx: Int =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            windowManager.maximumWindowMetrics.bounds.width()
-        } else {
-            @Suppress("DEPRECATION")
-            context.resources.displayMetrics.widthPixels
-        }
-    private val displayWidthDp: Int = (displayWidthPx / density).toInt()
+    // Full display width, used by the island to size itself as a percentage of the screen. Read from
+    // the *current* window metrics so it follows the device between portrait and landscape — recomputed
+    // on rotation by [onOrientationChanged]. (maximumWindowMetrics would stay pinned to the natural
+    // orientation, leaving the landscape pill and its touchable-region carve-out mis-sized.) The px value
+    // is read live by the touchable region; the dp value is a flow so the pill re-sizes on rotation
+    // without recreating the ComposeView.
+    private var displayWidthPx: Int = computeDisplayWidthPx()
+    private val displayWidthDp = MutableStateFlow((displayWidthPx / density).toInt())
+
+    // The orientation the live window geometry was built for, so [onOrientationChanged] only reacts to
+    // an actual portrait <-> landscape flip. Also the single source of truth for the current
+    // orientation, ready for orientation-specific layout settings later.
+    private var currentOrientation: Int = context.resources.configuration.orientation
 
     private val currentEvent = MutableStateFlow<IslandEvent?>(null)
     private val layoutState = MutableStateFlow(IslandLayout.DEFAULT)
@@ -181,9 +187,9 @@ class IslandOverlayController(private val context: Context) {
     // The installed OnComputeInternalInsetsListener (a reflection Proxy), kept so it can be removed.
     private var insetsListener: Any? = null
 
-    // True while the window has been torn down because "hide on lockscreen" is on and the device is
-    // locked. Guards signal handling and drives whether the window currently exists.
-    private var lockHidden = false
+    // True while the window has been torn down because "hide on lockscreen" or "hide in landscape" is active.
+    // Guards signal handling and drives whether the window currently exists.
+    private var overlayHidden = false
 
     // Re-evaluate lock visibility whenever the screen or lock state changes. All are protected
     // system broadcasts.
@@ -242,30 +248,73 @@ class IslandOverlayController(private val context: Context) {
     }
 
     /**
-     * Enforce "hide on lockscreen" by fully adding or removing the overlay window as the lock state
-     * changes. Tearing the window down — rather than just hiding it — means nothing is composed or
-     * drawn while the device is locked, which matters on low-end hardware. Re-checked on screen
-     * on/off, on unlock, and whenever the setting itself is toggled. Idempotent: the [lockHidden]
-     * guard makes repeat calls in the same state no-ops.
+     * Enforce "hide on lockscreen" and "hide in landscape" by fully adding or removing the overlay window.
+     * Tearing the window down — rather than just hiding it — means nothing is composed or drawn while
+     * locked or in landscape, and gesture areas stay completely unblocked.
      */
     private fun applyLockVisibility() {
-        val shouldHide = behaviourState.value.hideOnLockscreen &&
+        val shouldHideLock = behaviourState.value.hideOnLockscreen &&
             keyguardManager?.isKeyguardLocked == true
+        val shouldHideLandscape = behaviourState.value.hideInLandscape &&
+            currentOrientation == Configuration.ORIENTATION_LANDSCAPE
+        val shouldHide = shouldHideLock || shouldHideLandscape
+
         when {
-            shouldHide && !lockHidden -> {
-                lockHidden = true
+            shouldHide && !overlayHidden -> {
+                overlayHidden = true
                 dismissJob?.cancel()
                 windowResizeJob?.cancel()
                 currentEvent.value = null
                 removeOverlay()
             }
 
-            !shouldHide && lockHidden -> {
-                lockHidden = false
+            !shouldHide && overlayHidden -> {
+                overlayHidden = false
                 addOverlay()
-                syncWindowHeight()
+                syncWindowSize()
             }
         }
+    }
+
+    /** The current window width in px, following the device's live orientation. */
+    private fun computeDisplayWidthPx(): Int {
+        val (width, height) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val bounds = windowManager.currentWindowMetrics.bounds
+            bounds.width() to bounds.height()
+        } else {
+            @Suppress("DEPRECATION")
+            val metrics = context.resources.displayMetrics
+            metrics.widthPixels to metrics.heightPixels
+        }
+        // In landscape mode, size relative to portrait width so the pill remains reasonably sized
+        // and leaves ample space on either side of the top edge for the notification shade pull.
+        return if (currentOrientation == Configuration.ORIENTATION_LANDSCAPE) {
+            minOf(width, height)
+        } else {
+            width
+        }
+    }
+
+    /**
+     * React to a device rotation. The pill sizes itself as a percentage of the screen width, so on a
+     * portrait <-> landscape flip both the pill and the window that hugs it ([syncWindowSize]) must be
+     * recomputed for the new width — otherwise the landscape window is sized for portrait and the band
+     * ends up covering the shade-pull area. Recompute the width, let the pill re-size via [displayWidthDp],
+     * and re-hug the window; the window is updated in place, never torn down (re-adding it leaves the
+     * overlay fully touchable).
+     *
+     * Gated on an actual portrait <-> landscape flip via [currentOrientation]; other configuration
+     * changes (font scale, night mode, …) are ignored. This is the hook for orientation-specific layout
+     * settings later — [currentOrientation] is the single place the live orientation is tracked.
+     */
+    fun onOrientationChanged(orientation: Int) {
+        if (orientation == currentOrientation) return
+        currentOrientation = orientation
+        displayWidthPx = computeDisplayWidthPx()
+        displayWidthDp.value = (displayWidthPx / density).toInt()
+        applyLockVisibility()
+        if (overlayHidden) return
+        syncWindowSize()
     }
 
     private fun addOverlay() {
@@ -279,6 +328,7 @@ class IslandOverlayController(private val context: Context) {
                 val forced by forcedExpanded.collectAsStateWithLifecycle()
                 val behaviour by behaviourState.collectAsStateWithLifecycle()
                 val appearance by appearanceState.collectAsStateWithLifecycle()
+                val widthDp by displayWidthDp.collectAsStateWithLifecycle()
                 // Theme the overlay so the "Dynamic color for all events" badge picks up the app's
                 // real primary / on-primary (Material You or the brand fallback), not the M3 baseline.
                 ExpressiveCutoutTheme {
@@ -286,7 +336,7 @@ class IslandOverlayController(private val context: Context) {
                         event = event,
                         collapsed = layout.collapsed,
                         expanded = layout.expanded,
-                        displayWidthDp = displayWidthDp,
+                        displayWidthDp = widthDp,
                         forcedExpanded = forced,
                         animationStyle = behaviour.animationStyle,
                         animationSpeed = behaviour.animationSpeed,
@@ -339,7 +389,7 @@ class IslandOverlayController(private val context: Context) {
         appearancePreferences.settings.collect {
             appearanceState.value = it
             // The action-button height feeds the expanded window's extra room; keep them in step.
-            syncWindowHeight()
+            syncWindowSize()
         }
     }
 
@@ -443,7 +493,7 @@ class IslandOverlayController(private val context: Context) {
      * nothing else has taken the cutout. Idempotent via [playerAppHidden].
      */
     private fun applyPlayerAppVisibility() {
-        if (previewPinned || lockHidden) return
+        if (previewPinned || overlayHidden) return
         if (shouldHideForPlayerApp()) {
             if (playerAppHidden) return
             playerAppHidden = true
@@ -452,7 +502,7 @@ class IslandOverlayController(private val context: Context) {
                 forcedExpanded.value = null
                 expanded = false
                 currentEvent.value = null
-                syncWindowHeight()
+                syncWindowSize()
             }
         } else {
             if (!playerAppHidden) return
@@ -462,7 +512,7 @@ class IslandOverlayController(private val context: Context) {
                     forcedExpanded.value = null
                     expanded = false
                     currentEvent.value = pill
-                    syncWindowHeight()
+                    syncWindowSize()
                 }
             }
         }
@@ -526,7 +576,7 @@ class IslandOverlayController(private val context: Context) {
     private fun observeLayout() = scope.launch {
         layoutPreferences.layout.collect { layout ->
             layoutState.value = layout
-            syncWindowHeight()
+            syncWindowSize()
         }
     }
 
@@ -536,36 +586,52 @@ class IslandOverlayController(private val context: Context) {
     }
 
     /**
-     * Resize the window to hug the current island state (collapsed vs expanded height), so the
-     * empty band below a collapsed pill stops swallowing touches. The pill itself is still
-     * animated inside Compose — this only changes the window at the two rest states, never per
-     * frame, so the expand/collapse animation stays smooth.
+     * Resize the window to hug the current island state (collapsed vs expanded) in *both* width and
+     * height, so the empty band around the pill stops swallowing touches — most importantly the
+     * notification-shade pull, which happens beside the pill. Hugging the width (not spanning the whole
+     * screen) is what keeps the shade reachable in landscape: the wide areas either side of the pill are
+     * then outside the window entirely and fall through, rather than relying on the touchable-region
+     * carve-out — which the framework does not honour for this overlay in landscape.
      *
-     * Grow/shrink is asymmetric: growing (expand) happens immediately so the window always has
-     * room for the pill before it animates open; shrinking (collapse) is deferred until the pill
-     * has finished collapsing, so the window never clips it mid-animation.
+     * The pill itself is still animated inside Compose — this only changes the window at the two rest
+     * states, never per frame, so the expand/collapse animation stays smooth.
+     *
+     * Width is held at the widest state (never varied on expand/collapse): the window is centred, so
+     * resizing its width mid-animation would re-centre it a frame out of step with the pill and make the
+     * pill appear to slide sideways. Height is safe to vary because the window is top-anchored (it grows
+     * downward), and is grown immediately on expand but shrunk only after the collapse animation finishes,
+     * so the window always has room for the pill and never clips it mid-animation.
      */
-    private fun syncWindowHeight() {
-        requestWindowHeight(windowHeightPx(layoutState.value, expanded))
+    private fun syncWindowSize() {
+        requestWindowSize(
+            windowWidthPx(layoutState.value),
+            windowHeightPx(layoutState.value, expanded),
+        )
     }
 
-    private fun requestWindowHeight(targetHeightPx: Int) {
+    private fun requestWindowSize(targetWidthPx: Int, targetHeightPx: Int) {
         val params = layoutParams ?: return
         windowResizeJob?.cancel()
-        if (targetHeightPx >= params.height) {
-            resizeWindowHeight(targetHeightPx)
-        } else {
+        val currentWidth = params.width
+        val currentHeight = params.height
+        // MATCH_PARENT is -1; treat it as "already large enough" so the first sizing shrinks straight to fit.
+        val grownWidth = if (currentWidth < 0) targetWidthPx else maxOf(targetWidthPx, currentWidth)
+        val grownHeight = maxOf(targetHeightPx, currentHeight)
+        resizeWindow(grownWidth, grownHeight)
+        val shrinks = (currentWidth >= 0 && targetWidthPx < currentWidth) || targetHeightPx < currentHeight
+        if (shrinks) {
             windowResizeJob = scope.launch {
                 delay(WINDOW_SHRINK_DELAY_MS)
-                resizeWindowHeight(targetHeightPx)
+                resizeWindow(targetWidthPx, targetHeightPx)
             }
         }
     }
 
-    private fun resizeWindowHeight(targetHeightPx: Int) {
+    private fun resizeWindow(targetWidthPx: Int, targetHeightPx: Int) {
         val view = composeView ?: return
         val params = layoutParams ?: return
-        if (params.height != targetHeightPx) {
+        if (params.width != targetWidthPx || params.height != targetHeightPx) {
+            params.width = targetWidthPx
             params.height = targetHeightPx
             runCatching { windowManager.updateViewLayout(view, params) }
         }
@@ -662,6 +728,24 @@ class IslandOverlayController(private val context: Context) {
         return ((dims.offsetYDp + dims.heightDp + bonus + WINDOW_MARGIN_DP) * density).toInt()
     }
 
+    /** Wide enough for whichever state is widest — used for the initial, safe window size. */
+    private fun windowWidthPx(layout: IslandLayout): Int =
+        maxOf(windowWidthPx(layout, expanded = false), windowWidthPx(layout, expanded = true))
+
+    /**
+     * Width needed to contain just one state's pill, centred, with room for its horizontal offset and a
+     * margin on each side (for the rounded edges, shadow and tap "boop" scale). Capped at the display
+     * width so a very wide pill falls back to a full-width band. Keeping this to the pill (rather than the
+     * whole screen) is what lets the notification shade be pulled from beside the pill in landscape.
+     */
+    private fun windowWidthPx(layout: IslandLayout, expanded: Boolean): Int {
+        val dims = effectiveDims(layout, expanded)
+        val pillWidthPx = displayWidthPx * dims.widthPercent / 100
+        val offsetXPx = (abs(dims.offsetXDp) * density).toInt()
+        val marginPx = (WINDOW_MARGIN_DP * density).toInt()
+        return (pillWidthPx + 2 * (offsetXPx + marginPx)).coerceAtMost(displayWidthPx)
+    }
+
     /**
      * The dimensions the island is actually drawn at right now: the expanded state when expanded, the
      * bigger call cutout when the shown event is a phone call (it has no expanded state), otherwise
@@ -687,7 +771,7 @@ class IslandOverlayController(private val context: Context) {
                         else -> 1
                     }
                     layout.collapsed.asCallCutout(
-                        callCutoutWidthPercent(event.label, trailingButtons, incoming, displayWidthDp, density),
+                        callCutoutWidthPercent(event.label, trailingButtons, incoming, displayWidthDp.value, density),
                     )
                 }
             }
@@ -744,14 +828,14 @@ class IslandOverlayController(private val context: Context) {
                     expanded = false
                     currentEvent.value = null
                 }
-                syncWindowHeight()
+                syncWindowSize()
             }
     }
 
     private fun observeSignals() = scope.launch {
         IslandEventBus.signals.collect { signal ->
-            // Window is torn down for the lockscreen — drop signals so nothing is queued behind it.
-            if (lockHidden) return@collect
+            // Window is torn down for lockscreen/landscape — drop signals so nothing is queued behind it.
+            if (overlayHidden) return@collect
             // Master switch: nothing shows when the cutout is disabled.
             if (!behaviourState.value.cutoutEnabled) return@collect
             // Skip system events the user disabled for the pill.
@@ -790,7 +874,7 @@ class IslandOverlayController(private val context: Context) {
                 eventAnimatedIconLoops,
                 eventColors,
             ).copy(initiallyExpanded = autoExpand)
-            syncWindowHeight()
+            syncWindowSize()
             // A music/call signal is only emitted while that tile is live, so pin it up rather than
             // starting the auto-dismiss timer — it stays for as long as playback / the call lasts.
             when (signal) {
@@ -822,7 +906,7 @@ class IslandOverlayController(private val context: Context) {
                 forcedExpanded.value = null
                 expanded = false
                 currentEvent.value = null
-                syncWindowHeight()
+                syncWindowSize()
             }
         }
     }
@@ -831,7 +915,7 @@ class IslandOverlayController(private val context: Context) {
     private fun onExpandedChanged(isExpanded: Boolean) {
         val wasExpanded = expanded
         expanded = isExpanded
-        syncWindowHeight()
+        syncWindowSize()
         when {
             isExpanded -> dismissJob?.cancel()
             previewPinned -> Unit
@@ -935,7 +1019,7 @@ class IslandOverlayController(private val context: Context) {
         expanded = false
         val returnToLive = livePillToReturnTo() != null
         currentEvent.value = null
-        syncWindowHeight()
+        syncWindowSize()
         if (returnToLive) {
             dismissJob = scope.launch {
                 delay(MUSIC_RETURN_DELAY_MS)
@@ -943,7 +1027,7 @@ class IslandOverlayController(private val context: Context) {
                     forcedExpanded.value = null
                     expanded = false
                     currentEvent.value = pill
-                    syncWindowHeight()
+                    syncWindowSize()
                 }
             }
         }
@@ -1034,17 +1118,19 @@ class IslandOverlayController(private val context: Context) {
                     currentEvent.value = null
                 }
             }
-            syncWindowHeight()
+            syncWindowSize()
         }
     }
 
     private fun buildLayoutParams(): WindowManager.LayoutParams {
         @Suppress("DEPRECATION")
         val overlayType = WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY
-        // Full-width, fixed-height band. Starts non-touchable (nothing showing) and becomes
-        // touchable only while the island is visible (so tap-to-expand works).
+        // A fixed band centred at the top, sized to hug the pill (see syncWindowSize) rather than span the
+        // whole screen — so the areas either side stay free for the notification-shade pull, in landscape
+        // too. Starts non-touchable (nothing showing) and becomes touchable only while the island is
+        // visible (so tap-to-expand works).
         return WindowManager.LayoutParams(
-            WindowManager.LayoutParams.MATCH_PARENT,
+            windowWidthPx(IslandLayout.DEFAULT),
             windowHeightPx(IslandLayout.DEFAULT),
             overlayType,
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or

--- a/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutAccessibilityService.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutAccessibilityService.kt
@@ -1,6 +1,7 @@
 package com.ekoehler.expressivecutout.service
 
 import android.accessibilityservice.AccessibilityService
+import android.content.res.Configuration
 import android.view.accessibility.AccessibilityEvent
 import com.ekoehler.expressivecutout.core.ForegroundAppBus
 import com.ekoehler.expressivecutout.events.MediaPlaybackMonitor
@@ -39,6 +40,16 @@ class CutoutAccessibilityService : AccessibilityService() {
         if (event?.eventType != AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) return
         val pkg = event.packageName?.toString()?.takeIf { it.isNotBlank() } ?: return
         ForegroundAppBus.update(pkg)
+    }
+
+    /**
+     * Forward device rotations to the overlay so it can rebuild its top-of-screen window for the new
+     * geometry — otherwise the touchable-region carve-out that lets the notification shade through
+     * beside the pill goes stale in landscape and the band swallows the shade pull.
+     */
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        overlay?.onOrientationChanged(newConfig.orientation)
     }
 
     override fun onInterrupt() = Unit

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
@@ -16,6 +16,7 @@ import com.ekoehler.expressivecutout.data.ReplyInputStyle
 import com.ekoehler.expressivecutout.data.SentAlignment
 import com.ekoehler.expressivecutout.data.BehaviourPreferences
 import com.ekoehler.expressivecutout.data.BehaviourSettings
+import com.ekoehler.expressivecutout.data.HorizontalCutoutMode
 import com.ekoehler.expressivecutout.data.CutoutColor
 import com.ekoehler.expressivecutout.data.CutoutFill
 import com.ekoehler.expressivecutout.data.DynamicRole
@@ -364,6 +365,10 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
 
     fun setHideInLandscape(enabled: Boolean) = viewModelScope.launch {
         behaviourPreferences.setHideInLandscape(enabled)
+    }
+
+    fun setHorizontalCutoutMode(mode: HorizontalCutoutMode) = viewModelScope.launch {
+        behaviourPreferences.setHorizontalCutoutMode(mode)
     }
 
     fun setAnimationStyle(style: AnimationStyle) = viewModelScope.launch {

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
@@ -362,6 +362,10 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         behaviourPreferences.setHideOnLockscreen(enabled)
     }
 
+    fun setHideInLandscape(enabled: Boolean) = viewModelScope.launch {
+        behaviourPreferences.setHideInLandscape(enabled)
+    }
+
     fun setAnimationStyle(style: AnimationStyle) = viewModelScope.launch {
         behaviourPreferences.setAnimationStyle(style)
     }

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/BehaviourScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/BehaviourScreen.kt
@@ -25,8 +25,16 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.RadioButton
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
 import com.ekoehler.expressivecutout.R
 import com.ekoehler.expressivecutout.data.BehaviourSettings
+import com.ekoehler.expressivecutout.data.HorizontalCutoutMode
 import com.ekoehler.expressivecutout.data.SwipeDismissDirection
 import com.ekoehler.expressivecutout.data.SwipeDismissTarget
 import com.ekoehler.expressivecutout.ui.AppViewModel
@@ -69,12 +77,31 @@ internal fun BehaviourScreen(
             checked = behaviour.hideOnLockscreen,
             onCheckedChange = viewModel::setHideOnLockscreen,
         )
-        SettingsToggleCard(
+        BehaviourRadioGroupCard(
             shape = groupedShape(isFirst = false, isLast = false),
-            title = stringResource(R.string.behaviour_hide_landscape),
-            description = stringResource(R.string.behaviour_hide_landscape_desc),
-            checked = behaviour.hideInLandscape,
-            onCheckedChange = viewModel::setHideInLandscape,
+            title = stringResource(R.string.behaviour_horizontal_cutout),
+            options = listOf(
+                RadioOption(
+                    title = stringResource(R.string.horizontal_cutout_hidden),
+                    description = stringResource(R.string.horizontal_cutout_hidden_desc),
+                ),
+                RadioOption(
+                    title = stringResource(R.string.horizontal_cutout_normal_only),
+                    description = stringResource(R.string.horizontal_cutout_normal_only_desc),
+                ),
+                RadioOption(
+                    title = stringResource(R.string.horizontal_cutout_stick_to_camera),
+                    description = stringResource(R.string.horizontal_cutout_stick_to_camera_desc),
+                ),
+                RadioOption(
+                    title = stringResource(R.string.horizontal_cutout_center),
+                    description = stringResource(R.string.horizontal_cutout_center_desc),
+                ),
+            ),
+            selectedIndex = behaviour.horizontalCutoutMode.ordinal,
+            onSelect = { index ->
+                viewModel.setHorizontalCutoutMode(HorizontalCutoutMode.entries[index])
+            },
         )
         BehaviourSliderRow(
             shape = groupedShape(isFirst = false, isLast = false),
@@ -226,3 +253,57 @@ private fun BehaviourSliderRow(
         }
     }
 }
+
+private data class RadioOption(
+    val title: String,
+    val description: String,
+)
+
+@Composable
+private fun BehaviourRadioGroupCard(
+    shape: Shape,
+    title: String,
+    options: List<RadioOption>,
+    selectedIndex: Int,
+    onSelect: (Int) -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = shape,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(text = title, style = MaterialTheme.typography.titleMedium)
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                options.forEachIndexed { index, option ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .clickable { onSelect(index) }
+                            .padding(horizontal = 8.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(text = option.title, style = MaterialTheme.typography.bodyMedium)
+                            Text(
+                                text = option.description,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Spacer(Modifier.width(12.dp))
+                        RadioButton(
+                            selected = (index == selectedIndex),
+                            onClick = { onSelect(index) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/BehaviourScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/BehaviourScreen.kt
@@ -69,6 +69,13 @@ internal fun BehaviourScreen(
             checked = behaviour.hideOnLockscreen,
             onCheckedChange = viewModel::setHideOnLockscreen,
         )
+        SettingsToggleCard(
+            shape = groupedShape(isFirst = false, isLast = false),
+            title = stringResource(R.string.behaviour_hide_landscape),
+            description = stringResource(R.string.behaviour_hide_landscape_desc),
+            checked = behaviour.hideInLandscape,
+            onCheckedChange = viewModel::setHideInLandscape,
+        )
         BehaviourSliderRow(
             shape = groupedShape(isFirst = false, isLast = false),
             label = stringResource(R.string.behaviour_normal_duration),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -264,6 +264,15 @@
     <string name="behaviour_hide_lockscreen_desc">Don\'t show the cutout while the device is locked. The overlay is fully removed until you unlock, so it uses no resources.</string>
     <string name="behaviour_hide_landscape">Hide in landscape</string>
     <string name="behaviour_hide_landscape_desc">Remove the overlay when the device is rotated horizontally, so it never blocks games, videos, or the notification shade.</string>
+    <string name="behaviour_horizontal_cutout">Horizontal cutout</string>
+    <string name="horizontal_cutout_hidden">Hidden</string>
+    <string name="horizontal_cutout_hidden_desc">Totally hides the cutout when the device is horizontal</string>
+    <string name="horizontal_cutout_normal_only">Normal-only</string>
+    <string name="horizontal_cutout_normal_only_desc">Only allows normal cutout (not expanded) when horizontal</string>
+    <string name="horizontal_cutout_stick_to_camera">Stick to camera</string>
+    <string name="horizontal_cutout_stick_to_camera_desc">Stays like in vertical mode, on the camera</string>
+    <string name="horizontal_cutout_center">Center</string>
+    <string name="horizontal_cutout_center_desc">Goes to the top center of the horizontal screen</string>
     <string name="behaviour_animation_duration">Animation duration</string>
     <string name="behaviour_normal_duration">Normal cutout duration</string>
     <string name="behaviour_auto_collapse">Collapse automatically</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -262,6 +262,8 @@
     <string name="animation_bounce_small">Small</string>
     <string name="behaviour_hide_lockscreen">Hide on lockscreen</string>
     <string name="behaviour_hide_lockscreen_desc">Don\'t show the cutout while the device is locked. The overlay is fully removed until you unlock, so it uses no resources.</string>
+    <string name="behaviour_hide_landscape">Hide in landscape</string>
+    <string name="behaviour_hide_landscape_desc">Remove the overlay when the device is rotated horizontally, so it never blocks games, videos, or the notification shade.</string>
     <string name="behaviour_animation_duration">Animation duration</string>
     <string name="behaviour_normal_duration">Normal cutout duration</string>
     <string name="behaviour_auto_collapse">Collapse automatically</string>


### PR DESCRIPTION
This branch was focusing the cutout on horizontally oriented screens. In this PR, I added a bugfix and a few options:
- [FIX] When in horizontal screen, the cutout took focus of the whole top screen. User weren't able to pull down notification panel,
- [FEAT] Added a "Horizontal cutout" setting in Settings>Behaviour that offers four options,

Here are the "Settings>Behaviour>Horizontal cutout" options:
- Hidden: the cutout is totally hidden in horizontal screen,
- Center: the cutout stands on the top center of the horizontal screen,
- Normal-only: like Center, but the cutout never expands,
- Stick to camera: stays at the same place than in vertical orientation (on the camera) and doesn't expand 