### PR TITLE
Feature/progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ top of your screen — all styled with Material Expressive shapes, springs and M
 colours, and all customisable down to the corner radius.
 
 It runs entirely on your device. The app has no internet permission at all, so nothing can
-be uploaded: no accounts, no analytics, no tracking, and it never asks Android which apps
-you have installed.
+be uploaded: no accounts, no analytics, no tracking.
 
 [![Download the latest release](https://img.shields.io/badge/Download-latest%20release-005AC1?style=for-the-badge&logo=github&logoColor=white)](https://github.com/EvanKoe/expressive-cutout/releases)
 [![Stars](https://img.shields.io/github/stars/EvanKoe/expressive-cutout?style=for-the-badge)](https://github.com/EvanKoe/expressive-cutout/stargazers)
 [![License](https://img.shields.io/badge/license-GPLv3-blue?style=for-the-badge)](LICENSE)
 [![Kotlin](https://img.shields.io/badge/Kotlin-Jetpack%20Compose-7F52FF?style=for-the-badge&logo=kotlin&logoColor=white)](https://kotlinlang.org)
+[![Discord](https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/SNfcuuJeYF)
 
 </div>
 
@@ -42,7 +42,8 @@ you have installed.
 | | | |
 |-|-|-|
 |<img width="864" height="1939" alt="Screenshot_20260729-153011" src="https://github.com/user-attachments/assets/9f7e4724-bd91-4486-8f0e-9500906024d2" />|<img width="1080" height="2424" alt="Screenshot_20260729-153006" src="https://github.com/user-attachments/assets/e803d2a2-8e9b-41e0-8688-54affaefa355" />|<img width="864" height="1939" alt="Screenshot_20260729-153043" src="https://github.com/user-attachments/assets/84f40ce3-7ef0-41b4-9d89-3790008de5bc" />|
-|<img width="1080" height="2424" alt="Screenshot_20260729-152844" src="https://github.com/user-attachments/assets/a905ca3b-ba28-41ff-a072-07752b79686a" />|<img width="1080" height="2424" alt="Screenshot_20260729-152838" src="https://github.com/user-attachments/assets/7f11c6b2-a736-4529-8718-268e6dba3852" />|<img width="1080" height="2424" alt="Screenshot_20260729-152826" src="https://github.com/user-attachments/assets/73a72048-8338-4c10-aeea-e4a1243b724a" />|
+| <img width="1080" height="2424" alt="Screenshot_20260807-111655" src="https://github.com/user-attachments/assets/7c4b132c-54ec-471b-a4c3-bf7ddc7d8846" /> | <img width="1080" height="2424" alt="Screenshot_20260807-111746" src="https://github.com/user-attachments/assets/1d59ac95-0dfb-4b4b-9b8c-2814eb436da1" /> | <img width="1080" height="2424" alt="Screenshot_20260807-112035" src="https://github.com/user-attachments/assets/33542dec-9d6b-456a-bc14-c779c1d07a00" /> |
+ | <img width="1080" height="2424" alt="Screenshot_20260807-112215" src="https://github.com/user-attachments/assets/e33224c9-fe29-4fa2-b580-e0e8a10c7237" /> |
 
 ---
 
@@ -56,10 +57,10 @@ you have installed.
 
 Requires Android 10 (API 29) or newer. On first launch the app walks you through the three
 things it needs: notification access (to mirror notifications), the accessibility service
-(to draw the overlay — no screen content is read), and optionally an exemption from battery
+(to draw the overlay), and optionally an exemption from battery
 optimisation so the island stays reliable in the background.
 
-Join our [Discord server](https://discord.gg/uG5XWj2N5v) for feedback, feature requests, bug report and share with the Expressive by Evan community!
+Join our [Discord server](https://discord.gg/SNfcuuJeYF) for feedback, feature requests, bug report and share with the Expressive by Evan community!
 
 ---
 
@@ -103,7 +104,7 @@ Even if this project started as a personal app, a lot of existing projects gave 
 
 And my very special thanks to [Sameerasw's Essential app for Android](https://github.com/sameerasw/essentials) which has an AWESOME Material You Expressive implementation. He is doing a great job and all his apps feel very polished. 
 
-Also, I would like to thank anyone who has or plans to contribute to the project, may it be by reporting bugs or making PRs.
+I would like to thank everyone that takes part to the project on Discord, Github and Reddit by submitting bugs, requesting features and creating issues.
 
 ---
 

--- a/app/src/main/assets/changelog.json
+++ b/app/src/main/assets/changelog.json
@@ -1,0 +1,152 @@
+[
+  {
+    "version": "0.1.2",
+    "description": "Per-app configuration and the assistant tile",
+    "features": [
+      "Per-app configuration: choose which apps the island reacts to, and restrict an app to the normal cutout only",
+      "Assistant dynamic tile"
+    ],
+    "bugfixes": [
+      "Music dynamic tile",
+      "Call dynamic tile"
+    ]
+  },
+  {
+    "version": "0.1.1",
+    "description": "Maintenance release",
+    "features": [
+      "Automated release builds through GitHub Actions"
+    ],
+    "bugfixes": [
+      "Dynamic tiles",
+      "Crash when the cutout corner radius was set to 0 dp",
+      "Horizontal notification panel"
+    ]
+  },
+  {
+    "version": "0.1.0",
+    "description": "First public beta — incoming calls and expressive animations",
+    "features": [
+      "Incoming-call tile with the caller's name, their number, and decline / answer buttons, opening the in-call view on tap",
+      "Animations screen: choose an expressive spring or ease-in-out style and tune speed and bounce against a live example",
+      "Every screen drops its title bar for a fading top edge, so the content starts higher and scrolls away under the status bar",
+      "Opt-in two-row incoming-call layout, with the number ellipsized under the name so it clears the camera",
+      "The expanded incoming layout now matches the expanded cutout size and uses a single bottom-aligned label",
+      "Incoming tile pinned to 80% of the screen width, with its own test-call button",
+      "Call cutout width adapts to the length of the caller's name",
+      "The in-app test call simulates a real incoming call",
+      "\"Buy me a coffee\" card in Profile"
+    ],
+    "bugfixes": []
+  },
+  {
+    "version": "0.0.8",
+    "description": "Per-event customisation",
+    "features": [
+      "Material icon selector for events, replacing the app-icon picker, with a search filter over the full icon library",
+      "Per-event duration settings",
+      "Animated-icon and loop toggles for each event",
+      "Per-event colour override with a reset",
+      "The charging event now animates"
+    ],
+    "bugfixes": []
+  },
+  {
+    "version": "0.0.7",
+    "description": "Timer tile",
+    "features": [
+      "Timer dynamic tile that mirrors the system countdown",
+      "Behaviour: slider to scale the island animation duration between 0 and 1000 ms",
+      "Appearance: stroke options animate in and out",
+      "Icon container colour for the phone and timer tiles, previewed in the tile list"
+    ],
+    "bugfixes": [
+      "Detect Android 16+ live-update timers, so Google Clock countdowns are picked up",
+      "Show the clock app's real button labels instead of substituted text",
+      "Pause flips to Resume live while the timer is paused",
+      "The timer pill dismisses immediately when the timer is reset",
+      "The settings list refreshes the accessibility grant on resume"
+    ]
+  },
+  {
+    "version": "0.0.6",
+    "description": "Phone tile and lockscreen behaviour",
+    "features": [
+      "Phone dynamic tile: live call with contact photo, call duration, and call actions",
+      "Hide on lockscreen — the overlay tears itself down while the device is locked",
+      "Predictive back gesture with a matching navigation animation",
+      "Unlock animation",
+      "Separate hang-up and secondary button colours on the phone tile",
+      "Event icons renamed to Events, with a dynamic primary-colour toggle for every event",
+      "Events can pick a Material You colour role and an opacity",
+      "Appearance and disappearance animation for the normal cutout",
+      "Overlay access card in the main settings list, and a reordered permissions screen",
+      "QUERY_ALL_PACKAGES replaced with a scoped queries declaration for launcher apps"
+    ],
+    "bugfixes": []
+  },
+  {
+    "version": "0.0.5",
+    "description": "Dynamic tiles and music playback",
+    "features": [
+      "Dynamic tiles, starting with a now-playing music tile: album art, playback controls, and per-tile settings screens",
+      "Album art spins while playback runs and freezes when paused",
+      "The music cutout stays pinned up for as long as playback is live",
+      "Customisable music tile buttons: colour, opacity, rounded corners, and shape presets",
+      "Swipe to dismiss, with its own settings",
+      "One shared colour picker with dynamic roles, hex entry, and overridable presets"
+    ],
+    "bugfixes": [
+      "Dynamic tiles split away from system events into their own model, prefs, and screen",
+      "The music tile no longer reappears after its notification is dismissed",
+      "More material play / pause button"
+    ]
+  },
+  {
+    "version": "0.0.4",
+    "description": "Backgrounds and swipe gestures",
+    "features": [
+      "Dedicated background screen: separate normal and expanded fills, gradients, and opacity",
+      "Shrink the expanded cutout by swiping up, toggleable in Behaviour",
+      "Segmented reply field — cancel, input, and send as one connected bar",
+      "Card in Profile that opens the GitHub repository"
+    ],
+    "bugfixes": [
+      "Touches around the cutout reach the notification shade without resizing the window"
+    ]
+  },
+  {
+    "version": "0.0.3",
+    "description": "Notifications and inline replies",
+    "features": [
+      "Notification actions and inline reply, plus the Wi-Fi network name on connect",
+      "Style options for the action buttons and the reply field",
+      "Customisable send / cancel reply button colours",
+      "Test notification with action buttons, inline reply, and a 15-second auto-dismiss"
+    ],
+    "bugfixes": [
+      "The preview reflects the action-button toggle, and swatch selection rings are no longer clipped",
+      "Back from Action buttons returns to Appearance, then to Settings",
+      "Removed the feature that required the background location permission"
+    ]
+  },
+  {
+    "version": "0.0.2",
+    "description": "Size, position and behaviour",
+    "features": [
+      "Size and position controls for the island, alongside the first behaviour options",
+      "Global switch to turn the cutout off entirely"
+    ],
+    "bugfixes": [
+      "Smoother animation, and a window-resize delay that stops the island from jumping"
+    ]
+  },
+  {
+    "version": "0.0.1",
+    "description": "First build",
+    "features": [
+      "Expressive Cutout: a dynamic island overlay for punch-hole displays"
+    ],
+    "bugfixes": []
+  }
+]

--- a/app/src/main/assets/changelog.json
+++ b/app/src/main/assets/changelog.json
@@ -1,6 +1,20 @@
 [
   {
-    "version": "0.1.2",
+    "version": "0.1.3-beta",
+    "description": "Settings save, SWE and progress bar",
+    "features": [
+      "Settings export and import as JSON: allows saving and device transfer",
+      "SWE (Shows When Empty): the cutout can now stay on the screen even when no notification is displayed",
+      "SWE options: you can configure SWE to start shortcuts and apps on click (or not)",
+      "Added progress notifications to normal and expanded cutout",
+      "Added haptics to the app navigation and the SWE",
+      "Added OLED black for cutout",
+      "Animations for action buttons"
+    ],
+    "bugfixes": []
+  },
+  {
+    "version": "0.1.2-beta",
     "description": "Per-app configuration and the assistant tile",
     "features": [
       "Per-app configuration: choose which apps the island reacts to, and restrict an app to the normal cutout only",
@@ -12,7 +26,7 @@
     ]
   },
   {
-    "version": "0.1.1",
+    "version": "0.1.1-beta",
     "description": "Maintenance release",
     "features": [
       "Automated release builds through GitHub Actions"
@@ -24,7 +38,7 @@
     ]
   },
   {
-    "version": "0.1.0",
+    "version": "0.1.0-beta",
     "description": "First public beta — incoming calls and expressive animations",
     "features": [
       "Incoming-call tile with the caller's name, their number, and decline / answer buttons, opening the in-call view on tap",
@@ -40,7 +54,7 @@
     "bugfixes": []
   },
   {
-    "version": "0.0.8",
+    "version": "0.0.8-alpha",
     "description": "Per-event customisation",
     "features": [
       "Material icon selector for events, replacing the app-icon picker, with a search filter over the full icon library",
@@ -52,7 +66,7 @@
     "bugfixes": []
   },
   {
-    "version": "0.0.7",
+    "version": "0.0.7-alpha",
     "description": "Timer tile",
     "features": [
       "Timer dynamic tile that mirrors the system countdown",
@@ -69,7 +83,7 @@
     ]
   },
   {
-    "version": "0.0.6",
+    "version": "0.0.6-alpha",
     "description": "Phone tile and lockscreen behaviour",
     "features": [
       "Phone dynamic tile: live call with contact photo, call duration, and call actions",
@@ -86,7 +100,7 @@
     "bugfixes": []
   },
   {
-    "version": "0.0.5",
+    "version": "0.0.5-alpha",
     "description": "Dynamic tiles and music playback",
     "features": [
       "Dynamic tiles, starting with a now-playing music tile: album art, playback controls, and per-tile settings screens",
@@ -103,7 +117,7 @@
     ]
   },
   {
-    "version": "0.0.4",
+    "version": "0.0.4-alpha",
     "description": "Backgrounds and swipe gestures",
     "features": [
       "Dedicated background screen: separate normal and expanded fills, gradients, and opacity",
@@ -116,7 +130,7 @@
     ]
   },
   {
-    "version": "0.0.3",
+    "version": "0.0.3-alpha",
     "description": "Notifications and inline replies",
     "features": [
       "Notification actions and inline reply, plus the Wi-Fi network name on connect",
@@ -131,7 +145,7 @@
     ]
   },
   {
-    "version": "0.0.2",
+    "version": "0.0.2-alpha",
     "description": "Size, position and behaviour",
     "features": [
       "Size and position controls for the island, alongside the first behaviour options",
@@ -142,7 +156,7 @@
     ]
   },
   {
-    "version": "0.0.1",
+    "version": "0.0.1-alpha",
     "description": "First build",
     "features": [
       "Expressive Cutout: a dynamic island overlay for punch-hole displays"

--- a/app/src/main/java/com/ekoehler/expressivecutout/core/CutoutSignal.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/core/CutoutSignal.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.rounded.Wifi
 import androidx.compose.material.icons.rounded.WifiOff
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.ekoehler.expressivecutout.R
+import com.ekoehler.expressivecutout.service.ProgressData
 
 /**
  * A raw, source-agnostic trigger emitted onto the [IslandEventBus]. Producers (the
@@ -45,6 +46,7 @@ sealed interface CutoutSignal {
          * a valid notification, and the fallback when [largeIcon] is null.
          */
         val smallIcon: Icon? = null,
+        val progressData: ProgressData? = null
     ) : CutoutSignal {
 
         /**

--- a/app/src/main/java/com/ekoehler/expressivecutout/core/NowPlaying.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/core/NowPlaying.kt
@@ -29,7 +29,40 @@ data class NowPlaying(
     val albumArt: ImageBitmap?,
     val isPlaying: Boolean,
     val transport: MediaTransport,
+    /** Where playback has got to, or null for a session that publishes no position. */
+    val progress: MediaProgress? = null,
 )
+
+/**
+ * Playback position as a self-advancing anchor rather than a live value. A media session only
+ * republishes its state when something *changes* — it does not tick — so [positionMs] is only true
+ * as of [anchorUptimeMs], and a reader extrapolates from there at [speed]. This is what lets the
+ * tile animate a moving bar without the monitor pushing an update several times a second.
+ */
+data class MediaProgress(
+    /** Position within the track as of [anchorUptimeMs]. */
+    val positionMs: Long,
+    /** Track length, or null when the session publishes none — a live stream, or a player that
+     *  simply omits it. The tile falls back to an indeterminate bar. */
+    val durationMs: Long?,
+    /** Rate the position advances at, 0 while paused. */
+    val speed: Float,
+    /** [android.os.SystemClock.elapsedRealtime] when [positionMs] was sampled. */
+    val anchorUptimeMs: Long,
+) {
+    /** The position right now, extrapolated from the anchor and clamped to the track length. */
+    fun positionAt(nowUptimeMs: Long): Long {
+        val elapsed = ((nowUptimeMs - anchorUptimeMs).coerceAtLeast(0L) * speed).toLong()
+        val position = positionMs + elapsed
+        return durationMs?.let { position.coerceIn(0L, it) } ?: position.coerceAtLeast(0L)
+    }
+
+    /** How far through the track, 0f..1f, or null while the length is unknown. */
+    fun fractionAt(nowUptimeMs: Long): Float? {
+        val total = durationMs?.takeIf { it > 0L } ?: return null
+        return (positionAt(nowUptimeMs).toFloat() / total).coerceIn(0f, 1f)
+    }
+}
 
 /** The transport actions the music tile exposes. Backed by the active media session's controls. */
 interface MediaTransport {

--- a/app/src/main/java/com/ekoehler/expressivecutout/data/MusicTilePreferences.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/data/MusicTilePreferences.kt
@@ -88,6 +88,8 @@ data class MusicTileSettings(
     val skipButton: MusicButtonStyle = MusicButtonStyle.DEFAULT,
     /** Style of the central play / pause button. */
     val playPauseButton: MusicButtonStyle = MusicButtonStyle.DEFAULT,
+    /** Show a playback progress bar under the transport controls. */
+    val showProgress: Boolean = DEFAULT_SHOW_PROGRESS,
 ) {
     companion object {
         const val DEFAULT_SHOW_ALBUM_ART = true
@@ -96,6 +98,7 @@ data class MusicTileSettings(
         const val DEFAULT_EXPAND_ON_PLAY = true
         const val DEFAULT_VISIBLE_IN_PLAYER_APP = true
         const val DEFAULT_SHOW_CONTROLS = true
+        const val DEFAULT_SHOW_PROGRESS = false
     }
 }
 
@@ -126,6 +129,7 @@ class MusicTilePreferences(private val context: Context) : JsonSerializable {
                     .coerceIn(MusicButtonStyle.MIN_CORNER_PERCENT, MusicButtonStyle.MAX_CORNER_PERCENT),
                 filled = prefs[PLAY_PAUSE_FILLED] ?: MusicButtonStyle.DEFAULT_FILLED,
             ),
+            showProgress = prefs[SHOW_PROGRESS] ?: MusicTileSettings.DEFAULT_SHOW_PROGRESS,
         )
     }
 
@@ -147,6 +151,7 @@ class MusicTilePreferences(private val context: Context) : JsonSerializable {
             put("expandOnPlay", s.expandOnPlay)
             put("visibleInPlayerApp", s.visibleInPlayerApp)
             put("showControls", s.showControls)
+            put("showProgress", s.showProgress)
             put("skipButton", s.skipButton.toJsonObject())
             put("playPauseButton", s.playPauseButton.toJsonObject())
         }.toString()
@@ -170,6 +175,7 @@ class MusicTilePreferences(private val context: Context) : JsonSerializable {
             if (obj.has("expandOnPlay")) prefs[EXPAND_ON_PLAY] = obj.getBoolean("expandOnPlay")
             if (obj.has("visibleInPlayerApp")) prefs[VISIBLE_IN_PLAYER_APP] = obj.getBoolean("visibleInPlayerApp")
             if (obj.has("showControls")) prefs[SHOW_CONTROLS] = obj.getBoolean("showControls")
+            if (obj.has("showProgress")) prefs[SHOW_PROGRESS] = obj.getBoolean("showProgress")
 
             obj.optJSONObject("skipButton")?.applyButton(prefs, SKIP_COLOR, SKIP_OPACITY, SKIP_CORNER, SKIP_FILLED)
             obj.optJSONObject("playPauseButton")
@@ -258,6 +264,10 @@ class MusicTilePreferences(private val context: Context) : JsonSerializable {
         it[PLAY_PAUSE_OPACITY] = opacity.coerceIn(0f, 1f)
     }
 
+    suspend fun setShowProgress(enabled: Boolean) = context.musicTileDataStore.edit {
+        it[SHOW_PROGRESS] = enabled
+    }
+
     suspend fun setPlayPauseCornerPercent(percent: Int) = context.musicTileDataStore.edit {
         it[PLAY_PAUSE_CORNER] = percent.coerceIn(
             MusicButtonStyle.MIN_CORNER_PERCENT,
@@ -305,5 +315,6 @@ class MusicTilePreferences(private val context: Context) : JsonSerializable {
         val PLAY_PAUSE_OPACITY = floatPreferencesKey("play_pause_button_opacity")
         val PLAY_PAUSE_CORNER = intPreferencesKey("play_pause_button_corner_percent")
         val PLAY_PAUSE_FILLED = booleanPreferencesKey("play_pause_button_filled")
+        val SHOW_PROGRESS = booleanPreferencesKey("show_current_progress")
     }
 }

--- a/app/src/main/java/com/ekoehler/expressivecutout/events/MediaPlaybackMonitor.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/events/MediaPlaybackMonitor.kt
@@ -7,6 +7,7 @@ import android.media.session.MediaController
 import android.media.session.MediaSessionManager
 import android.media.session.PlaybackState
 import android.net.Uri
+import android.os.SystemClock
 import android.util.Log
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.core.content.getSystemService
@@ -14,6 +15,7 @@ import androidx.core.net.toUri
 import com.ekoehler.expressivecutout.core.CutoutSignal
 import com.ekoehler.expressivecutout.core.DynamicTile
 import com.ekoehler.expressivecutout.core.IslandEventBus
+import com.ekoehler.expressivecutout.core.MediaProgress
 import com.ekoehler.expressivecutout.core.MediaTransport
 import com.ekoehler.expressivecutout.core.NowPlaying
 import com.ekoehler.expressivecutout.core.NowPlayingBus
@@ -183,6 +185,7 @@ class MediaPlaybackMonitor(private val context: Context) {
                 albumArt = albumArt,
                 isPlaying = playing,
                 transport = ControllerTransport(primary),
+                progress = primary.progress(metadata, playing),
             ),
         )
 
@@ -207,6 +210,29 @@ class MediaPlaybackMonitor(private val context: Context) {
 
     private val MediaController.isPlaying: Boolean
         get() = playbackState?.state == PlaybackState.STATE_PLAYING
+
+    /**
+     * The session's position anchor. [PlaybackState.getPosition] is a sample taken at
+     * [PlaybackState.getLastPositionUpdateTime], not a live figure — it is passed through as-is and
+     * the tile extrapolates. Players that publish no duration, or a negative one for a live stream,
+     * yield a null length and an indeterminate bar. A state carrying [PlaybackState.PLAYBACK_POSITION_UNKNOWN]
+     * gives no anchor at all.
+     */
+    private fun MediaController.progress(metadata: MediaMetadata?, playing: Boolean): MediaProgress? {
+        val state = playbackState ?: return null
+        if (state.position == PlaybackState.PLAYBACK_POSITION_UNKNOWN) return null
+
+        val duration = metadata?.getLong(MediaMetadata.METADATA_KEY_DURATION)?.takeIf { it > 0L }
+        // A paused session keeps its position but must not creep; a player reporting a nonsense
+        // speed while playing is treated as ordinary 1x rather than freezing the bar.
+        val speed = if (playing) state.playbackSpeed.takeIf { it > 0f } ?: 1f else 0f
+        return MediaProgress(
+            positionMs = state.position.coerceAtLeast(0L),
+            durationMs = duration,
+            speed = speed,
+            anchorUptimeMs = state.lastPositionUpdateTime.takeIf { it > 0L } ?: SystemClock.elapsedRealtime(),
+        )
+    }
 
     /**
      * The cover the session itself carries: a bitmap if the player published one, else a URI we can

--- a/app/src/main/java/com/ekoehler/expressivecutout/notifications/TestNotifier.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/notifications/TestNotifier.kt
@@ -17,6 +17,13 @@ import androidx.core.content.ContextCompat
 import com.ekoehler.expressivecutout.R
 import com.ekoehler.expressivecutout.core.CutoutSignal
 import com.ekoehler.expressivecutout.core.IslandEventBus
+import com.ekoehler.expressivecutout.service.ProgressData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import android.app.RemoteInput as PlatformRemoteInput
 
 /**
@@ -28,9 +35,18 @@ object TestNotifier {
 
     private const val CHANNEL_ID = "test"
     const val NOTIFICATION_ID = 4711
+    const val PROGRESS_NOTIFICATION_ID = 4712
 
     /** The notification auto-dismisses after this long so the test never lingers. */
     private const val TIMEOUT_MS = 15_000L
+
+    private const val PROGRESS_MAX = 100
+    private const val PROGRESS_STEP = 5
+    private const val PROGRESS_SWEEP_MS = 5_000L
+    private const val PROGRESS_KEY = "test-progress"
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private var progressJob: Job? = null
 
     /** True once a notification can actually be posted (Android 13+ gates this at runtime). */
     fun canPost(context: Context): Boolean =
@@ -105,6 +121,62 @@ object TestNotifier {
                 smallIcon = Icon.createWithResource(context, R.drawable.ic_stat_island),
             ),
         )
+    }
+
+    /**
+     * Posts a real progress notification and mirrors it onto the island, sweeping the bar from 0 to
+     * [PROGRESS_MAX] over [PROGRESS_SWEEP_MS] so the progress pipeline (extras -> [ProgressData] ->
+     * the cutout) can be watched filling up without waiting on a real download. Each step re-posts
+     * the system notification and re-emits the island signal under a stable [PROGRESS_KEY], which the
+     * overlay updates in place — the same channel a real app re-posting its download uses. Re-tapping
+     * cancels any sweep already running.
+     */
+    @SuppressLint("MissingPermission")
+    fun sendProgress(context: Context) {
+        ensureChannel(context)
+        val appContext = context.applicationContext
+        val title = appContext.getString(R.string.test_progress_notification_title)
+        val text = appContext.getString(R.string.test_progress_notification_text)
+
+        progressJob?.cancel()
+        progressJob = scope.launch {
+            var current = 0
+            while (true) {
+                val notification = NotificationCompat.Builder(appContext, CHANNEL_ID)
+                    .setSmallIcon(R.drawable.ic_stat_island)
+                    .setContentTitle(title)
+                    .setContentText(text)
+                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+                    .setOnlyAlertOnce(true)
+                    .setProgress(PROGRESS_MAX, current, false)
+                    .setTimeoutAfter(TIMEOUT_MS)
+                    .build()
+
+                if (canPost(appContext)) {
+                    NotificationManagerCompat.from(appContext).notify(PROGRESS_NOTIFICATION_ID, notification)
+                }
+
+                IslandEventBus.emit(
+                    CutoutSignal.Notification(
+                        packageName = appContext.packageName,
+                        title = title,
+                        text = text,
+                        key = PROGRESS_KEY,
+                        smallIcon = Icon.createWithResource(appContext, R.drawable.ic_stat_island),
+                        progressData = ProgressData(
+                            max = PROGRESS_MAX,
+                            current = current,
+                            isIndeterminate = false,
+                            title = title,
+                        ),
+                    ),
+                )
+
+                if (current >= PROGRESS_MAX) break
+                delay(PROGRESS_SWEEP_MS * PROGRESS_STEP / PROGRESS_MAX)
+                current = (current + PROGRESS_STEP).coerceAtMost(PROGRESS_MAX)
+            }
+        }
     }
 
     /** A mutable broadcast [PendingIntent] to [TestReplyReceiver]; mutability lets reply text fill in. */

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
@@ -121,6 +121,9 @@ import android.net.Uri
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import kotlinx.coroutines.Dispatchers
@@ -152,6 +155,7 @@ import com.ekoehler.expressivecutout.data.MusicButtonStyle
 import com.ekoehler.expressivecutout.data.ReplyInputStyle
 import com.ekoehler.expressivecutout.data.SwipeDismissDirection
 import com.ekoehler.expressivecutout.data.SwipeDismissTarget
+import com.ekoehler.expressivecutout.service.ProgressData
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.abs
@@ -387,23 +391,12 @@ fun DynamicIsland(
         else -> collapsed
     }
 
-    // The assistant streams its answer as a rapid series of fresh events, each with a new id (the
-    // resolver stamps one per emission). Keying this on the id would reset it to 0 on every token, so
-    // the fit-to-content height would keep collapsing to its 110dp floor and springing back — the
-    // bounce. Key it on the tile kind instead so the measured height persists across the whole stream
-    // and only resets when a different (non-assistant) event takes over.
     var assistantContentHeightDp by remember(shownEvent?.assistant != null) { mutableStateOf(0) }
-    // The empty pill's center fits its own content: the shortcut row measures itself so the cutout is
-    // exactly as tall as it needs to be (shorter with labels off), instead of a fixed reservation.
     var centerContentHeightDp by remember { mutableStateOf(0) }
     val screenHeightDp = LocalConfiguration.current.screenHeightDp
 
     val heightBonus = when {
         emptyPill && isExpanded -> {
-            // Fit the cutout to the measured shortcut content (camera clearance + content), so it's
-            // exactly as tall as needed — shorter with labels off. Falls back to the reserve until
-            // the first measurement lands. dims is the expanded layout, so this resolves the island
-            // height to (collapsed clearance + gap + content) regardless of the expanded height.
             if (centerContentHeightDp > 0) {
                 collapsed.heightDp + CENTER_TOP_GAP_DP + centerContentHeightDp - dims.heightDp
             } else {
@@ -423,9 +416,6 @@ fun DynamicIsland(
         else -> 0
     }
 
-    // Appear / disappear reveal: the cutout emerges as a small, camera-sized dot and stretches out
-    // horizontally to its full width, then shrinks back into the dot when it's dismissed. `reveal`
-    // runs 0 (dot) → 1 (full pill); it eases in on show and back out on hide.
     val present = event != null || showsWhenEmpty
     val reveal = remember { Animatable(0f) }
 
@@ -481,16 +471,12 @@ fun DynamicIsland(
     val topRight by animateDpAsState(if (isStickToCamera) cornerRadius else dims.cornerTopRightDp.dp, spec, label = "cornerTR")
     val bottomLeft by animateDpAsState(if (isStickToCamera) cornerRadius else dims.cornerBottomLeftDp.dp, spec, label = "cornerBL")
     val bottomRight by animateDpAsState(if (isStickToCamera) cornerRadius else dims.cornerBottomRightDp.dp, spec, label = "cornerBR")
-    // Drives the background cross-fade between the normal and expanded fills, in step with the size.
     val expandProgress by animateFloatAsState(
         targetValue = if (isExpanded) 1f else 0f,
         animationSpec = motion.fade(),
         label = "islandBackgroundFade",
     )
 
-    // The dot's diameter is the cutout's own (collapsed) height — the camera-sized nub it grows from —
-    // so the normal cutout keeps that height throughout and only its width expands. Corners stay fully
-    // round while it's a dot and ease to the configured shape as it opens out.
     val dotDp = collapsed.heightDp.dp
     val revealWidth = lerpDp(dotDp, width, reveal.value)
     val revealHeight = lerpDp(dotDp, height, reveal.value)
@@ -508,14 +494,12 @@ fun DynamicIsland(
         val stickPaddingStart = if (isStickToCamera && !isRotation270) offsetYDp.dp else 0.dp
         val stickPaddingEnd = if (isStickToCamera && isRotation270) offsetYDp.dp else 0.dp
 
-        // Position the island in the full-size (non-clipping) window; then animate visibility.
         Box(
             modifier = Modifier
                 .align(if (isStickToCamera) stickAlignment else Alignment.TopCenter)
                 .padding(start = stickPaddingStart, end = stickPaddingEnd)
                 .offset(x = if (isStickToCamera) 0.dp else offsetX, y = if (isStickToCamera) 0.dp else offsetY),
         ) {
-            // Keep rendering through the exit (until `reveal` reaches 0) so the shrink-back animates.
             if (present || reveal.value > 0f) {
                 IslandSurface(
                     modifier = Modifier
@@ -709,8 +693,6 @@ fun DynamicIsland(
                         } else {
                             shownEvent?.let { e ->
                                 if (e.call != null) {
-                                    // The phone tile: one bigger normal cutout — caller on the left,
-                                    // hang-up on the right — with no separate expanded layout.
                                     CallNormalContent(event = e, onAction = onAction)
                                 } else if (showExpanded) {
                                     ExpandedContent(
@@ -719,14 +701,11 @@ fun DynamicIsland(
                                         appearance = appearance,
                                         replyingTo = replyingTo,
                                         replySent = confirmingSent,
+                                        progressData = e.progressData,
                                         onAction = onAction,
                                         onStartReply = { replyingTo = it },
                                         onCancelReply = { replyingTo = null },
                                         onSendReply = { text ->
-                                            // Swap the field for the "Sent" confirmation, then dispatch
-                                            // the reply once it has been seen. Launched from the (un-keyed)
-                                            // composition scope so a notification arriving mid-hold can't
-                                            // cancel the send.
                                             replyingTo?.let { action ->
                                                 sentReply = action to text
                                                 scope.launch {
@@ -811,21 +790,19 @@ private fun IslandSurface(
 ) {
     val normalBrush = appearance.backgroundNormal.resolveBrush()
     val expandedBrush = appearance.backgroundExpanded.resolveBrush()
-    // Keep text/icons legible: dark ink on a light fill, otherwise the near-white default. The
-    // reference colour tracks the fade so ink flips at the right moment when the states differ.
     val repColor = lerp(
         appearance.backgroundNormal.representativeColor(),
         appearance.backgroundExpanded.representativeColor(),
         progress,
     )
+
     val contentColor = if (repColor.luminance() > 0.5f) PillTextColorDark else PillTextColor
     val border = if (appearance.strokeEnabled) {
         BorderStroke(appearance.strokeWidthDp.dp, appearance.strokeColor.resolve())
     } else {
         null
     }
-    // The Surface itself is transparent (so a gradient fill is possible); the fill is drawn by the
-    // opaque child below, which also keeps the layer opaque so the elevation shadow still renders.
+
     Surface(
         modifier = modifier,
         shape = shape,
@@ -936,6 +913,35 @@ private fun CollapsedContent(event: IslandEvent, heightDp: Int, isStickToCamera:
                     modifier = Modifier
                         .align(Alignment.CenterEnd)
                         .padding(end = (heightDp * 0.24f).dp),
+                )
+            }
+        }
+        event.progressData?.takeIf { !isStickToCamera }?.let { progress ->
+            val indicatorModifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(end = (heightDp * 0.24f).dp)
+                .size((heightDp * 0.5f).dp)
+            val strokeWidth = (heightDp * 0.06f).dp
+            if (progress.isIndeterminate) {
+                CircularProgressIndicator(
+                    modifier = indicatorModifier,
+                    color = MaterialTheme.colorScheme.primary,
+                    trackColor = MaterialTheme.colorScheme.primaryContainer,
+                    strokeWidth = strokeWidth,
+                )
+            } else {
+                val fraction = if (progress.max <= 0) 0f
+                    else (progress.current.toFloat() / progress.max).coerceIn(0f, 1f)
+                val animatedFraction by animateFloatAsState(
+                    targetValue = fraction,
+                    label = "collapsedProgress",
+                )
+                CircularProgressIndicator(
+                    progress = { animatedFraction },
+                    modifier = indicatorModifier,
+                    color = MaterialTheme.colorScheme.primary,
+                    trackColor = MaterialTheme.colorScheme.primaryContainer,
+                    strokeWidth = strokeWidth,
                 )
             }
         }
@@ -1257,6 +1263,7 @@ private fun ExpandedContent(
     appearance: AppearanceSettings,
     replyingTo: IslandAction?,
     replySent: Boolean,
+    progressData: ProgressData? = null,
     onAction: (IslandAction) -> Unit,
     onStartReply: (IslandAction) -> Unit,
     onCancelReply: () -> Unit,
@@ -1316,18 +1323,45 @@ private fun ExpandedContent(
                             overflow = TextOverflow.Ellipsis,
                         )
                     }
+
+                    var lastProgressData by remember { mutableStateOf(progressData) }
+                    if (progressData != null) lastProgressData = progressData
+                    AnimatedVisibility(visible = progressData != null) {
+                        lastProgressData?.let { p ->
+                            if (p.isIndeterminate) {
+                                LinearProgressIndicator(
+                                    color = MaterialTheme.colorScheme.primary,
+                                    trackColor = MaterialTheme.colorScheme.primaryContainer,
+                                    strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
+                                )
+                            } else {
+                                val fraction = if (p.max <= 0) 0f
+                                    else (p.current.toFloat() / p.max).coerceIn(0f, 1f)
+                                val animatedFraction by animateFloatAsState(
+                                    targetValue = fraction,
+                                    label = "notificationProgress",
+                                )
+                                LinearProgressIndicator(
+                                    progress = { animatedFraction },
+                                    color = MaterialTheme.colorScheme.primary,
+                                    trackColor = MaterialTheme.colorScheme.primaryContainer,
+                                    strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
+                                )
+                            }
+                        }
+                    }
                 }
             }
+
             // Fall back to the notification's own accent / a neutral tint when unset.
             val sendColor = appearance.sendButtonColor?.resolve() ?: event.accent
             when {
-                // Just sent: a brief confirmation replaces the field before the island dismisses.
                 replySent -> ReplySentRow(
                     tint = sendColor,
                     heightDp = appearance.actionButtonHeightDp,
                     alignment = appearance.sentAlignment,
                 )
-                // Typing a reply: the input field replaces the chips until sent or cancelled.
+
                 replyingTo != null -> ReplyRow(
                     hint = replyingTo.reply?.hint,
                     accent = event.accent,
@@ -1339,10 +1373,8 @@ private fun ExpandedContent(
                     onSend = onSendReply,
                     onCancel = onCancelReply,
                 )
-                // Action chips (at most three fit comfortably); a reply chip opens the input,
-                // any other chip fires its action.
+
                 showActions && event.actions.isNotEmpty() -> {
-                    // Chip fill follows the configured colour, or the notification's accent when unset.
                     val chipFill = appearance.actionButtonColor?.resolve() ?: event.accent
                     ActionChipRow(
                         actions = event.actions.take(3),

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
@@ -68,6 +68,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -130,6 +131,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import com.ekoehler.expressivecutout.R
 import com.ekoehler.expressivecutout.core.MediaArtBus
+import com.ekoehler.expressivecutout.core.MediaProgress
 import com.ekoehler.expressivecutout.core.NowPlaying
 import com.ekoehler.expressivecutout.core.NowPlayingBus
 import com.ekoehler.expressivecutout.core.OnCall
@@ -188,6 +190,11 @@ private const val ALBUM_SPIN_MS = 8000
 // the same on the collapsed pill and in the (larger) expanded layout.
 private const val ALBUM_STROKE_FRACTION = 0.055f
 private const val ALBUM_STROKE_GAP_FRACTION = 0.06f
+
+// How often the music progress bar re-reads its own clock. The media session pushes nothing between
+// real changes, so this is the bar's only motion; a whole bar width is a track long, which makes
+// even a half-second step sub-pixel.
+private const val PROGRESS_TICK_MS = 500L
 
 // The tuned baseline for the island's primary expand/collapse transition. Every tween-based
 // animation is expressed relative to this, so the user's single "animation duration" knob scales
@@ -288,23 +295,14 @@ fun DynamicIsland(
 
     val initialExpandedState = if (forcedExpanded == false) false else (shownEvent?.initiallyExpanded ?: false)
     var tapExpanded by remember(shownEvent?.id, forcedExpanded) { mutableStateOf(initialExpandedState) }
-    // Bumped on every center shortcut press so the auto-collapse timer restarts on interaction —
-    // the open center only shrinks after the inactivity delay, not a fixed time after it opened.
     var centerInteraction by remember { mutableStateOf(0) }
-    // The reply action currently being typed for, if any. Reset when the event changes.
     var replyingTo by remember(shownEvent?.id) { mutableStateOf<IslandAction?>(null) }
     val replying = replyingTo != null
-    // Non-null immediately after the user hits send: the island shows a brief "Sent" confirmation,
-    // then this action/text pair is dispatched (which dismisses the island).
     var sentReply by remember(shownEvent?.id) { mutableStateOf<Pair<IslandAction, String>?>(null) }
     val confirmingSent = sentReply != null
-    // The phone tile has no expanded state (and assistant when display answer is false): shown as normal cutout, so tapping never expands it.
     val isCall = shownEvent?.call != null
     val isAssistantNormalOnly = shownEvent?.assistant != null && !shownEvent.assistant.displayAnswerInCutout
     val isNormalOnly = isCall || isAssistantNormalOnly || shownEvent?.normalOnly == true
-    // The resting empty pill has no event, but with "Open center" a tap expands it into a shortcut
-    // grid. That reuses [tapExpanded] so it inherits auto-collapse; every other empty pill (and the
-    // normal-only tiles) stays collapsed.
     val centerExpanded = emptyPill && emptyOpensCenter && tapExpanded
     val isExpanded = when {
         forcedExpanded == false -> false
@@ -312,40 +310,25 @@ fun DynamicIsland(
         isNormalOnly -> false
         else -> forcedExpanded ?: tapExpanded
     }
+
     val boopScale = remember { Animatable(1f) }
-    // The cutout body's tap feedback follows the same setting as its buttons: [ActionButtonAnimation.SCALE]
-    // squishes the whole pill via [boopScale], [ActionButtonAnimation.EXPAND] widens it instead — this runs
-    // 0 (resting) → 1 (pressed) and only ever leaves 0 for that flavour, so the two never fight.
     val pressExpand = remember { Animatable(0f) }
     val pressWidens = actionButtonAnimation == ActionButtonAnimation.EXPAND
-    // Horizontal drag offset for swipe-to-dismiss; reset for each new event so a fresh pill starts centred.
     val dismissOffsetX = remember(shownEvent?.id) { Animatable(0f) }
     val scope = rememberCoroutineScope()
 
-    // One user-tunable knob scales every tween-based island animation — the expand/collapse, the
-    // pop-in/out reveal, the background fade, the content crossfade and the tap "boop" — in
-    // proportion to its tuned baseline, so the whole motion speeds up or slows down together.
-    // At 0ms everything snaps instantly; at the default (BASE_TRANSITION_MS) the feel is unchanged.
     val animScale = animationDurationMs / BASE_TRANSITION_MS.toFloat()
     fun scaled(baseMs: Int) = (baseMs * animScale).roundToInt()
 
-    // The island's primary motion (reveal, size / position / corners, background fade) follows the
-    // configured style: expressive spatial springs (speed picked by the user, durations ignored) or
-    // a standard ease-in-out tween scaled by the animation-duration slider. IslandMotion is shared
-    // with the settings example pills, so the preview there shows exactly this motion.
     val motion = remember(animationStyle, animationSpeed, animationBounce, animationDurationMs) {
         IslandMotion(animationStyle, animationSpeed, animationBounce, animationDurationMs)
     }
 
-    // Tell the controller to make the window focusable (for the keyboard) and pause dismissal.
     LaunchedEffect(replying) { onReplyActiveChange(replying) }
     LaunchedEffect(isExpanded, event != null, emptyPill, emptyOpensCenter) {
-        // Fire for real events, and for the empty pill's center so the controller grows the host
-        // window and touchable region to cover the expanded shortcut grid.
         if (event != null || (emptyPill && emptyOpensCenter)) onExpandedChange(isExpanded)
     }
-    // User-expanded (not the pinned preview) optionally collapses after the delay — never while
-    // a reply is being typed or its "sent" confirmation is still showing.
+
     LaunchedEffect(tapExpanded, forcedExpanded, autoCollapse, autoCollapseMs, replying, confirmingSent, centerInteraction) {
         if (forcedExpanded == null && tapExpanded && autoCollapse && !replying && !confirmingSent) {
             delay(autoCollapseMs)
@@ -353,15 +336,10 @@ fun DynamicIsland(
         }
     }
 
-    // Only pad the height when the expanded island will actually render a bottom row of controls —
-    // notification action chips, the music tile's playback buttons, or the phone tile's call actions.
     val hasActions = showActions && (shownEvent?.actions?.isNotEmpty() == true)
     val hasMediaControls = shownEvent?.media?.showControls == true
     val hasCallActions = shownEvent?.call?.showActions == true && (shownEvent?.actions?.isNotEmpty() == true)
     val hasTimerActions = shownEvent?.timer?.showActions == true && (shownEvent?.actions?.isNotEmpty() == true)
-    // An incoming call in its two-row layout puts the buttons on their own row (none trailing); a
-    // one-line incoming shows two trailing buttons (decline + answer); a connected call shows one
-    // (hang up). Read live from the call bus so the pill re-sizes when the call is answered.
     val liveCall by OnCallBus.state.collectAsStateWithLifecycle()
     val callIncoming = isCall && liveCall?.ongoing == false
     val callTwoRow = callIncoming && shownEvent?.call?.incomingExpandedLayout == true && hasCallActions
@@ -371,8 +349,7 @@ fun DynamicIsland(
         callIncoming -> 2
         else -> 1
     }
-    // The call cutout widens to fit a long caller name (up to its max); measured once per name/state.
-    // Any incoming call is pinned to the full width; the two-row layout also uses the taller shape.
+
     val density = LocalDensity.current.density
     val callWidthPercent = remember(isCall, shownEvent?.label, callTrailingButtons, callIncoming, displayWidthDp, density) {
         if (isCall) {
@@ -382,7 +359,6 @@ fun DynamicIsland(
         }
     }
 
-    // The two-row incoming layout starts from the expanded cutout and grows by its button row.
     val dims = when {
         emptyPill && !isExpanded -> collapsed
         callTwoRow -> expanded
@@ -425,15 +401,9 @@ fun DynamicIsland(
             animationSpec = motion.float(baseMs = if (present) 320 else 200),
         )
     }
-    // A dismiss swipe leaves the pill translated and faded (the alpha is derived from that offset), and
-    // [dismissOffsetX] is keyed on the sticky [shownEvent] so it survives the event clearing. With
-    // "shows when empty" the surface then never goes away, so the resting pill would sit off-centre at
-    // reduced opacity. Finish the exit instead: hide it, recentre, and grow back from the dot as usual.
-    // `present` is true either side of this hand-off, so the reveal above never competes for `reveal`.
+
     LaunchedEffect(emptyPill) {
         if (emptyPill) {
-            // A fresh resting pill always starts with its center closed — never inherit a prior
-            // notification's expanded state (after opening its app, swiping it away, etc.).
             tapExpanded = false
             if (dismissOffsetX.value != 0f) {
                 reveal.snapTo(0f)
@@ -442,28 +412,25 @@ fun DynamicIsland(
             }
         }
     }
-    // While the pill is fully hidden (reveal at 0) the size / position / corners snap straight to the
-    // next state instead of animating: a cutout dismissed while expanded resets to its normal height
-    // off-screen, so the next appearance grows from the dot at the right height with no catch-up lag.
+
     val spec: AnimationSpec<Dp> = if (reveal.value == 0f) snap() else motion.dp()
-    // While the assistant streams its answer the target height creeps up token by token; the bouncy
-    // spatial spring would re-overshoot on every nudge and make the cutout bob (see `dpSmooth`). Grow
-    // that height with a critically damped spring instead, but keep the springy `spec` for the normal
-    // expand/collapse (and while the pill is hidden, where the size snaps straight to the next state).
     val isAssistantAnswer = isExpanded && shownEvent?.assistant?.displayAnswerInCutout == true
     val heightSpec: AnimationSpec<Dp> = when {
         reveal.value == 0f -> snap()
         isAssistantAnswer -> motion.dpSmooth()
         else -> spec
     }
+
     val width by animateDpAsState(
         if (isStickToCamera) collapsed.heightDp.dp else (displayWidthDp * dims.widthPercent / 100f).dp,
         spec, label = "islandWidth"
     )
+
     val height by animateDpAsState(
         if (isStickToCamera) (displayWidthDp * dims.widthPercent / 100f).dp else (dims.heightDp + heightBonus).dp,
         heightSpec, label = "islandHeight"
     )
+
     val cornerRadius = (collapsed.heightDp / 2f).dp
     val offsetX by animateDpAsState(if (isStickToCamera) 0.dp else dims.offsetXDp.dp, spec, label = "islandOffsetX")
     val offsetY by animateDpAsState(if (isStickToCamera) 0.dp else dims.offsetYDp.dp, spec, label = "islandOffsetY")
@@ -1034,8 +1001,8 @@ private fun CenterContent(
     onShortcut: (CenterShortcut) -> Unit,
 ) {
     val density = LocalDensity.current.density
-    // Only togglable shortcuts have a lit state; the torch reads live from the bus.
     val torchOn by TorchStateBus.on.collectAsStateWithLifecycle()
+
     Box(modifier = Modifier.fillMaxSize().padding(horizontal = 18.dp)) {
         Column(
             modifier = Modifier
@@ -1944,6 +1911,11 @@ private fun MediaExpandedContent(event: IslandEvent, buttonHeightDp: Int) {
                     }
                 }
             }
+
+            event.media?.takeIf { it.showProgress }?.let {
+                MediaProgressBar(progress = nowPlaying?.progress)
+            }
+
             event.media?.takeIf { it.showControls }?.let { media ->
                 MediaControls(
                     isPlaying = nowPlaying?.isPlaying == true,
@@ -1959,6 +1931,48 @@ private fun MediaExpandedContent(event: IslandEvent, buttonHeightDp: Int) {
             }
         }
     }
+}
+
+/**
+ * The music tile's playback bar. [MediaProgress] is an anchor rather than a live position — the
+ * media session only republishes on a real change, never on a tick — so this drives its own clock
+ * while playback runs and extrapolates from that anchor. A session that publishes no track length
+ * (a live stream) gets the indeterminate bar instead, matching the notification tile's.
+ */
+@Composable
+private fun MediaProgressBar(progress: MediaProgress?) {
+    val color = MaterialTheme.colorScheme.primary
+    val trackColor = MaterialTheme.colorScheme.primaryContainer
+
+    if (progress?.durationMs == null) {
+        LinearProgressIndicator(
+            modifier = Modifier.fillMaxWidth(),
+            color = color,
+            trackColor = trackColor,
+            strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
+        )
+        return
+    }
+
+    // Re-anchored on every new snapshot, so a seek or a track change lands immediately rather than
+    // being animated across from the stale position.
+    var fraction by remember(progress) {
+        mutableFloatStateOf(progress.fractionAt(SystemClock.elapsedRealtime()) ?: 0f)
+    }
+    LaunchedEffect(progress) {
+        while (progress.speed > 0f) {
+            delay(PROGRESS_TICK_MS)
+            fraction = progress.fractionAt(SystemClock.elapsedRealtime()) ?: 0f
+        }
+    }
+
+    LinearProgressIndicator(
+        progress = { fraction },
+        modifier = Modifier.fillMaxWidth(),
+        color = color,
+        trackColor = trackColor,
+        strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
+    )
 }
 
 /**

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IconResolver.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IconResolver.kt
@@ -177,6 +177,7 @@ class IconResolver(private val context: Context) {
                 albumArtStroke = settings.albumArtStroke,
                 albumArtStrokeColor = settings.albumArtStrokeColor,
                 showControls = settings.showControls,
+                showProgress = settings.showProgress,
                 skipStyle = settings.skipButton,
                 playPauseStyle = settings.playPauseButton,
             ),

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IconResolver.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IconResolver.kt
@@ -19,6 +19,7 @@ import com.ekoehler.expressivecutout.data.MusicTileSettings
 import com.ekoehler.expressivecutout.data.PhoneTileSettings
 import com.ekoehler.expressivecutout.data.TimerTileSettings
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.math.sign
 
 /**
  * The Lottie animation to use for events that read better as motion than a static glyph, or null for
@@ -130,6 +131,7 @@ class IconResolver(private val context: Context) {
             themeColorOpacity = dynamicEventColorOpacity,
             contentIntent = signal.contentIntent,
             notificationKey = signal.key,
+            progressData = signal.progressData,
             actions = signal.actions.map { action ->
                 IslandAction(
                     label = action.title,

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandEvent.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandEvent.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import com.ekoehler.expressivecutout.data.CutoutColor
 import com.ekoehler.expressivecutout.data.DynamicRole
 import com.ekoehler.expressivecutout.data.MusicButtonStyle
+import com.ekoehler.expressivecutout.service.ProgressData
 
 /**
  * A fully resolved, ready-to-render icon. Reducing every possible source (a Material
@@ -122,6 +123,11 @@ data class IslandEvent(
      * in the cutout, capped at [maxCutoutHeightPercent] of screen height. Null otherwise.
      */
     val assistant: AssistantTileOptions? = null,
+    /**
+     * Contains the progress of this notification if it is a progress one.
+     * Is null otherwise
+     */
+    val progressData: ProgressData? = null
 )
 
 /** Which parts of the assistant tile to render (display text, max height). */

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandEvent.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandEvent.kt
@@ -169,6 +169,8 @@ data class MediaTileOptions(
     /** Colour of that ring; null falls back to the tile's accent. */
     val albumArtStrokeColor: CutoutColor? = null,
     val showControls: Boolean,
+    /** Show the playback progress bar under the controls. */
+    val showProgress: Boolean = false,
     /** Look of the previous / next (skip) buttons. */
     val skipStyle: MusicButtonStyle = MusicButtonStyle.DEFAULT,
     /** Look of the central play / pause button. */

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
@@ -416,8 +416,6 @@ class IslandOverlayController(private val context: Context) {
                     behaviour.horizontalCutoutMode == HorizontalCutoutMode.STICK_TO_CAMERA
                 val rot270 = isRotation270()
 
-                // Theme the overlay so the "Dynamic color for all events" badge picks up the app's
-                // real primary / on-primary (Material You or the brand fallback), not the M3 baseline.
                 ExpressiveCutoutTheme {
                     DynamicIsland(
                         event = event,

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
@@ -1123,6 +1123,16 @@ class IslandOverlayController(private val context: Context) {
 
             if (!behaviourState.value.cutoutEnabled) return@collect
 
+            val existing = currentEvent.value
+            if (signal is CutoutSignal.Notification && signal.key != null &&
+                existing != null && existing.notificationKey == signal.key
+            ) {
+                currentEvent.value = resolvedEvent.copy(id = existing.id)
+                syncWindowSize()
+                scheduleDismiss()
+                return@collect
+            }
+
             // Remember the system event (if any) so its auto-dismiss honours its per-event duration.
             currentSystemEventType = (signal as? CutoutSignal.System)?.type
             forcedExpanded.value = if (isNoExpandLandscape) false else null

--- a/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
@@ -21,6 +21,17 @@ import com.ekoehler.expressivecutout.events.CallNotificationParser
 import com.ekoehler.expressivecutout.events.TimerNotificationParser
 import com.ekoehler.expressivecutout.overlay.loadImageBitmapOrNull
 
+
+/**
+ * This is a progress data class to store progress notification extra data
+ */
+data class ProgressData(
+    val max: Int = 0,
+    val current: Int = 0,
+    val isIndeterminate: Boolean = false,
+    val title: String? = null
+)
+
 /**
  * Mirrors freshly posted notifications onto the island. It keeps only the posting package,
  * title and text (shown when the island is expanded) and filters out noise (its own posts,
@@ -62,24 +73,51 @@ class CutoutNotificationListenerService : NotificationListenerService() {
         super.onDestroy()
     }
 
+    /**
+     * Checks if the notification is a progress one
+     */
+    fun isProgressNotification(sbn: StatusBarNotification): Boolean {
+        return sbn.notification.extras.containsKey(Notification.EXTRA_PROGRESS)
+    }
+
+    /**
+     * Returns progress data from a notification (or null if no progress)
+     */
+    fun getProgressDataOrNull(sbn: StatusBarNotification): ProgressData? {
+        if (!sbn.notification.extras.containsKey(Notification.EXTRA_PROGRESS)) {
+            return null
+        }
+
+        val extras = sbn.notification.extras
+        val max = extras.getInt(Notification.EXTRA_PROGRESS_MAX, 0)
+        val current = extras.getInt(Notification.EXTRA_PROGRESS, 0)
+        val isIndeterminate = extras.getBoolean(Notification.EXTRA_PROGRESS_INDETERMINATE, false)
+        val title = extras.getString(Notification.EXTRA_TITLE)
+
+        return ProgressData(
+            max = max,
+            current = current,
+            isIndeterminate = isIndeterminate,
+            title = title
+        )
+    }
+
     override fun onNotificationPosted(sbn: StatusBarNotification?) {
         val notification = sbn ?: return
-        // Ongoing-call notifications drive the phone tile, not the normal notification pill (and
-        // would be dropped by shouldSurface below as ongoing anyway), so handle them first.
+
+        // Phone call
         if (CallNotificationParser.isCall(notification)) {
             handleCall(notification)
             return
         }
-        // A count-down notification drives the timer tile, not the normal pill (and is ongoing, so it
-        // would be dropped by shouldSurface below anyway), so handle it before the generic path.
+
+        // Timer
         if (TimerNotificationParser.isTimer(notification)) {
             handleTimer(notification)
             return
         }
-        // A player's MediaStyle notification carries the album cover as its large icon. Lift it
-        // before shouldSurface() drops the notification for being ongoing — it is the only cover we
-        // can get for a player that publishes its art as a remote URI rather than a bitmap. This
-        // deliberately does not return: whether the notification also becomes a pill is unchanged.
+
+        // Music
         notification.publishMediaArt()
 
         if (!notification.shouldSurface()) return
@@ -87,6 +125,7 @@ class CutoutNotificationListenerService : NotificationListenerService() {
         val extras = notification.notification.extras
         val title = extras?.getCharSequence(Notification.EXTRA_TITLE)?.toString()
         val text = extras?.getCharSequence(Notification.EXTRA_TEXT)?.toString()
+        val progress = getProgressDataOrNull(sbn)
 
         IslandEventBus.emit(
             CutoutSignal.Notification(
@@ -96,26 +135,25 @@ class CutoutNotificationListenerService : NotificationListenerService() {
                 key = notification.key,
                 contentIntent = notification.notification.contentIntent,
                 actions = notification.notification.surfaceableActions(),
-                // The posting app's own icons for this notification. Preferred over its launcher
-                // icon downstream, so the island badge shows what the shade shows.
                 largeIcon = notification.notification.getLargeIcon(),
                 smallIcon = notification.notification.smallIcon,
+                progressData = progress
             ),
         )
     }
 
     override fun onNotificationRemoved(sbn: StatusBarNotification?) {
-        // The dialer clears its notification when the call ends — drop the phone tile's live state.
+        // Clears call cutout when call ends
         if (sbn?.key != null && sbn.key == currentCallKey) {
             currentCallKey = null
             OnCallBus.update(null)
         }
-        // The clock clears its notification when the timer is reset or finishes — drop the tile.
+        // Clears time cutout when timer finishes or reset
         if (sbn?.key != null && sbn.key == currentTimerKey) {
             currentTimerKey = null
             RunningTimerBus.update(null)
         }
-        // The player cleared its media notification — the cover it carried is no longer current.
+        // Clears music cutout when music is paused/stopped
         if (sbn?.key != null && sbn.key == currentMediaArtKey) {
             currentMediaArtKey = null
             MediaArtBus.update(null)
@@ -131,6 +169,7 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     private fun handleCall(sbn: StatusBarNotification) {
         val call = CallNotificationParser.parse(sbn, this)
         val prevOngoing = OnCallBus.state.value?.ongoing
+
         OnCallBus.update(
             OnCall(
                 callerLabel = call.callerLabel,
@@ -141,6 +180,7 @@ class CutoutNotificationListenerService : NotificationListenerService() {
                 packageName = sbn.packageName,
             ),
         )
+
         if (sbn.key != currentCallKey || prevOngoing != call.ongoing) {
             currentCallKey = sbn.key
             IslandEventBus.emit(
@@ -262,7 +302,7 @@ class CutoutNotificationListenerService : NotificationListenerService() {
          */
         fun requestRebind(context: Context) {
             val component = ComponentName(context, CutoutNotificationListenerService::class.java)
-            runCatching { NotificationListenerService.requestRebind(component) }
+            runCatching { requestRebind(component) }
                 .onFailure { Log.w(TAG, "Failed to request listener rebind", it) }
         }
 
@@ -274,23 +314,6 @@ class CutoutNotificationListenerService : NotificationListenerService() {
             val service = instance ?: return
             runCatching { service.cancelNotification(key) }
                 .onFailure { Log.w(TAG, "Failed to cancel notification $key", it) }
-        }
-
-        /**
-         * Look up active notifications posted by [packageName] and return a pair of (title, text/bigText).
-         */
-        fun getNotificationTextForPackage(packageName: String): Pair<String?, String?>? {
-            val service = instance ?: return null
-            val notifications = runCatching { service.activeNotifications }.getOrNull() ?: return null
-            val sbn = notifications.firstOrNull { it.packageName.equals(packageName, ignoreCase = true) } ?: return null
-            val extras = sbn.notification?.extras ?: return null
-            val title = extras.getCharSequence(Notification.EXTRA_TITLE)?.toString()
-                ?: extras.getCharSequence("android.title")?.toString()
-            val bigText = extras.getCharSequence(Notification.EXTRA_BIG_TEXT)?.toString()
-                ?: extras.getCharSequence(Notification.EXTRA_TEXT)?.toString()
-                ?: extras.getCharSequence(Notification.EXTRA_SUB_TEXT)?.toString()
-                ?: extras.getCharSequence(Notification.EXTRA_SUMMARY_TEXT)?.toString()
-            return Pair(title, bigText)
         }
     }
 }

--- a/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
@@ -77,26 +77,28 @@ class CutoutNotificationListenerService : NotificationListenerService() {
      * Checks if the notification is a progress one
      */
     fun isProgressNotification(sbn: StatusBarNotification): Boolean {
-        return sbn.notification.extras.containsKey(Notification.EXTRA_PROGRESS)
+        return getProgressDataOrNull(sbn) != null
     }
 
     /**
-     * Returns progress data from a notification (or null if no progress)
+     * Returns progress data from a notification (or null if no progress).
+     *
+     * The progress extras are written by [Notification.Builder] for every notification, whether or
+     * not setProgress() was ever called, so their presence proves nothing. Only a positive max
+     * (determinate) or the indeterminate flag marks a notification as actually carrying progress.
      */
     fun getProgressDataOrNull(sbn: StatusBarNotification): ProgressData? {
-        if (!sbn.notification.extras.containsKey(Notification.EXTRA_PROGRESS)) {
-            return null
-        }
-
-        val extras = sbn.notification.extras
+        val extras = sbn.notification?.extras ?: return null
         val max = extras.getInt(Notification.EXTRA_PROGRESS_MAX, 0)
         val current = extras.getInt(Notification.EXTRA_PROGRESS, 0)
         val isIndeterminate = extras.getBoolean(Notification.EXTRA_PROGRESS_INDETERMINATE, false)
-        val title = extras.getString(Notification.EXTRA_TITLE)
+        val title = extras.getCharSequence(Notification.EXTRA_TITLE)?.toString()
+
+        if (!isIndeterminate && max <= 0) return null
 
         return ProgressData(
             max = max,
-            current = current,
+            current = current.coerceIn(0, max.coerceAtLeast(0)),
             isIndeterminate = isIndeterminate,
             title = title
         )

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
@@ -700,4 +700,8 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     fun setSentAlignment(alignment: SentAlignment) = viewModelScope.launch {
         appearancePreferences.setSentAlignment(alignment)
     }
+
+    fun setMusicShowProgress(enabled: Boolean) = viewModelScope.launch {
+        musicTilePreferences.setShowProgress(enabled)
+    }
 }

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/ChangelogScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/ChangelogScreen.kt
@@ -1,5 +1,6 @@
 package com.ekoehler.expressivecutout.ui.screen
 
+import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -19,7 +20,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.BugReport
-import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -27,202 +27,65 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.ekoehler.expressivecutout.R
+import org.json.JSONArray
+
+/** The asset holding the release history, edited by hand when a release is cut. */
+private const val ChangelogAsset = "changelog.json"
 
 /**
- * One entry in the release history. The bullet text is kept here rather than in strings.xml so a
- * release can be described in one place when it is cut; only the section headers are localised.
+ * One entry in the release history. The bullet text lives in [ChangelogAsset] rather than in
+ * strings.xml so a release can be described in one place when it is cut; only the section headers
+ * are localised.
  */
 internal data class Release(
     val version: String,
-    val headline: String,
-    val major: List<String> = emptyList(),
-    val minor: List<String> = emptyList(),
-    val fixes: List<String> = emptyList(),
+    val description: String,
+    val features: List<String> = emptyList(),
+    val bugfixes: List<String> = emptyList(),
 )
 
 /**
- * The release history, newest first — the first entry is the current build. 0.1.0 is the first
- * beta; everything numbered below it was a development build that was never published.
+ * Reads the release history from [ChangelogAsset], newest first — the first entry is taken as the
+ * current build. A missing or malformed asset yields an empty history rather than a crash, so a
+ * typo while filling the file in only costs the changelog its content.
  */
-internal val Releases: List<Release> = listOf(
-    Release(
-        version = "0.1.2",
-        headline = "Per-app configuration and the assistant tile",
-        major = listOf(
-            "Per-app configuration: choose which apps the island reacts to, and restrict an app to the normal cutout only",
-            "Assistant dynamic tile",
-        ),
-        fixes = listOf(
-            "Music dynamic tile",
-            "Call dynamic tile",
-        ),
-    ),
-    Release(
-        version = "0.1.1",
-        headline = "Maintenance release",
-        minor = listOf(
-            "Automated release builds through GitHub Actions",
-        ),
-        fixes = listOf(
-            "Dynamic tiles",
-            "Crash when the cutout corner radius was set to 0 dp",
-            "Horizontal notification panel",
-        ),
-    ),
-    Release(
-        version = "0.1.0",
-        headline = "First public beta — incoming calls and expressive animations",
-        major = listOf(
-            "Incoming-call tile with the caller's name, their number, and decline / answer buttons, opening the in-call view on tap",
-            "Animations screen: choose an expressive spring or ease-in-out style and tune speed and bounce against a live example",
-        ),
-        minor = listOf(
-            "Every screen drops its title bar for a fading top edge, so the content starts higher and scrolls away under the status bar",
-            "Opt-in two-row incoming-call layout, with the number ellipsized under the name so it clears the camera",
-            "The expanded incoming layout now matches the expanded cutout size and uses a single bottom-aligned label",
-            "Incoming tile pinned to 80% of the screen width, with its own test-call button",
-            "Call cutout width adapts to the length of the caller's name",
-            "The in-app test call simulates a real incoming call",
-            "\"Buy me a coffee\" card in Profile",
-        ),
-    ),
-    Release(
-        version = "0.0.8",
-        headline = "Per-event customisation",
-        major = listOf(
-            "Material icon selector for events, replacing the app-icon picker, with a search filter over the full icon library",
-        ),
-        minor = listOf(
-            "Per-event duration settings",
-            "Animated-icon and loop toggles for each event",
-            "Per-event colour override with a reset",
-            "The charging event now animates",
-        ),
-    ),
-    Release(
-        version = "0.0.7",
-        headline = "Timer tile",
-        major = listOf(
-            "Timer dynamic tile that mirrors the system countdown",
-        ),
-        minor = listOf(
-            "Behaviour: slider to scale the island animation duration between 0 and 1000 ms",
-            "Appearance: stroke options animate in and out",
-            "Icon container colour for the phone and timer tiles, previewed in the tile list",
-        ),
-        fixes = listOf(
-            "Detect Android 16+ live-update timers, so Google Clock countdowns are picked up",
-            "Show the clock app's real button labels instead of substituted text",
-            "Pause flips to Resume live while the timer is paused",
-            "The timer pill dismisses immediately when the timer is reset",
-            "The settings list refreshes the accessibility grant on resume",
-        ),
-    ),
-    Release(
-        version = "0.0.6",
-        headline = "Phone tile and lockscreen behaviour",
-        major = listOf(
-            "Phone dynamic tile: live call with contact photo, call duration, and call actions",
-            "Hide on lockscreen — the overlay tears itself down while the device is locked",
-        ),
-        minor = listOf(
-            "Predictive back gesture with a matching navigation animation",
-            "Unlock animation",
-            "Separate hang-up and secondary button colours on the phone tile",
-            "Event icons renamed to Events, with a dynamic primary-colour toggle for every event",
-            "Events can pick a Material You colour role and an opacity",
-            "Appearance and disappearance animation for the normal cutout",
-            "Overlay access card in the main settings list, and a reordered permissions screen",
-            "QUERY_ALL_PACKAGES replaced with a scoped queries declaration for launcher apps",
-        ),
-    ),
-    Release(
-        version = "0.0.5",
-        headline = "Dynamic tiles and music playback",
-        major = listOf(
-            "Dynamic tiles, starting with a now-playing music tile: album art, playback controls, and per-tile settings screens",
-        ),
-        minor = listOf(
-            "Album art spins while playback runs and freezes when paused",
-            "The music cutout stays pinned up for as long as playback is live",
-            "Customisable music tile buttons: colour, opacity, rounded corners, and shape presets",
-            "Swipe to dismiss, with its own settings",
-            "One shared colour picker with dynamic roles, hex entry, and overridable presets",
-        ),
-        fixes = listOf(
-            "Dynamic tiles split away from system events into their own model, prefs, and screen",
-            "The music tile no longer reappears after its notification is dismissed",
-            "More material play / pause button",
-        ),
-    ),
-    Release(
-        version = "0.0.4",
-        headline = "Backgrounds and swipe gestures",
-        major = listOf(
-            "Dedicated background screen: separate normal and expanded fills, gradients, and opacity",
-        ),
-        minor = listOf(
-            "Shrink the expanded cutout by swiping up, toggleable in Behaviour",
-            "Segmented reply field — cancel, input, and send as one connected bar",
-            "Card in Profile that opens the GitHub repository",
-        ),
-        fixes = listOf(
-            "Touches around the cutout reach the notification shade without resizing the window",
-        ),
-    ),
-    Release(
-        version = "0.0.3",
-        headline = "Notifications and inline replies",
-        major = listOf(
-            "Notification actions and inline reply, plus the Wi-Fi network name on connect",
-        ),
-        minor = listOf(
-            "Style options for the action buttons and the reply field",
-            "Customisable send / cancel reply button colours",
-            "Test notification with action buttons, inline reply, and a 15-second auto-dismiss",
-        ),
-        fixes = listOf(
-            "The preview reflects the action-button toggle, and swatch selection rings are no longer clipped",
-            "Back from Action buttons returns to Appearance, then to Settings",
-            "Removed the feature that required the background location permission",
-        ),
-    ),
-    Release(
-        version = "0.0.2",
-        headline = "Size, position and behaviour",
-        major = listOf(
-            "Size and position controls for the island, alongside the first behaviour options",
-        ),
-        minor = listOf(
-            "Global switch to turn the cutout off entirely",
-        ),
-        fixes = listOf(
-            "Smoother animation, and a window-resize delay that stops the island from jumping",
-        ),
-    ),
-    Release(
-        version = "0.0.1",
-        headline = "First build",
-        major = listOf(
-            "Expressive Cutout: a dynamic island overlay for punch-hole displays",
-        ),
-    ),
-)
+internal fun loadReleases(context: Context): List<Release> = runCatching {
+    val text = context.assets.open(ChangelogAsset).bufferedReader().use { it.readText() }
+    val entries = JSONArray(text)
+    List(entries.length()) { index ->
+        val entry = entries.getJSONObject(index)
+        Release(
+            version = entry.optString("version"),
+            description = entry.optString("description"),
+            features = entry.optJSONArray("features").toStringList(),
+            bugfixes = entry.optJSONArray("bugfixes").toStringList(),
+        )
+    }
+}.getOrDefault(emptyList())
+
+/** Flattens a bullet array into a list, treating an absent key as no bullets of that kind. */
+private fun JSONArray?.toStringList(): List<String> =
+    if (this == null) emptyList() else List(length()) { getString(it) }
 
 /**
- * "What's new": the full release history, newest first, with each release split into major
- * features, minor features and bug fixes. Reached from the version card in Profile.
+ * "What's new": the full release history, newest first, with each release split into features and
+ * bug fixes. Reached from the version card in Profile.
  */
 @Composable
 fun ChangelogScreen(contentPadding: PaddingValues) {
+    val context = LocalContext.current
+    val releases = remember { loadReleases(context) }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -237,7 +100,7 @@ fun ChangelogScreen(contentPadding: PaddingValues) {
             modifier = Modifier.padding(bottom = 4.dp),
         )
 
-        Releases.forEachIndexed { index, release ->
+        releases.forEachIndexed { index, release ->
             ReleaseCard(release = release, isCurrent = index == 0)
         }
     }
@@ -279,28 +142,22 @@ private fun ReleaseCard(release: Release, isCurrent: Boolean) {
                 }
             }
             Text(
-                text = release.headline,
+                text = release.description,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
             ReleaseGroup(
                 icon = Icons.Rounded.AutoAwesome,
-                label = stringResource(R.string.changelog_major),
+                label = stringResource(R.string.changelog_features),
                 accent = MaterialTheme.colorScheme.primary,
-                items = release.major,
-            )
-            ReleaseGroup(
-                icon = Icons.Rounded.Tune,
-                label = stringResource(R.string.changelog_minor),
-                accent = MaterialTheme.colorScheme.tertiary,
-                items = release.minor,
+                items = release.features,
             )
             ReleaseGroup(
                 icon = Icons.Rounded.BugReport,
                 label = stringResource(R.string.changelog_fixes),
                 accent = MaterialTheme.colorScheme.secondary,
-                items = release.fixes,
+                items = release.bugfixes,
             )
         }
     }

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/PermissionDetailsScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/PermissionDetailsScreen.kt
@@ -45,7 +45,7 @@ import com.ekoehler.expressivecutout.R
 /**
  * One permission, explained: what it is, and the specific things the app does with it. The copy
  * lives here rather than in strings.xml so a permission is described next to the manifest entry it
- * documents, the same way [Releases] keeps its bullets in code.
+ * documents.
  */
 private data class PermissionDoc(
     val icon: ImageVector,

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/PermissionsTab.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/PermissionsTab.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.rounded.BatterySaver
 import androidx.compose.material.icons.rounded.Call
 import androidx.compose.material.icons.rounded.CallReceived
 import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Downloading
 import androidx.compose.material.icons.rounded.Layers
 import androidx.compose.material.icons.rounded.Notifications
 import androidx.compose.material.icons.rounded.NotificationsActive
@@ -69,18 +70,24 @@ fun PermissionsTab(contentPadding: PaddingValues) {
     val context = LocalContext.current
     val status = rememberPermissionStatus()
 
-    // Android 13+ gates posting behind a runtime permission; grant then post.
+    // Android 13+ gates posting behind a runtime permission; grant then run the pending post.
+    var pendingPost by remember { mutableStateOf<(() -> Unit)?>(null) }
     val postPermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
-    ) { granted -> if (granted) TestNotifier.send(context) }
+    ) { granted -> if (granted) pendingPost?.invoke() }
 
-    fun onTestNotification() {
+    fun postWithPermission(send: () -> Unit) {
         if (TestNotifier.canPost(context)) {
-            TestNotifier.send(context)
+            send()
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            pendingPost = send
             postPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
     }
+
+    fun onTestNotification() = postWithPermission { TestNotifier.send(context) }
+
+    fun onTestProgressNotification() = postWithPermission { TestNotifier.sendProgress(context) }
 
     Column(
         modifier = Modifier
@@ -136,6 +143,13 @@ fun PermissionsTab(contentPadding: PaddingValues) {
                 icon = Icons.Rounded.NotificationsActive,
                 title = stringResource(R.string.action_send_test),
                 onClick = ::onTestNotification,
+            )
+
+            // Send a test progress notification
+            TestCard(
+                icon = Icons.Rounded.Downloading,
+                title = stringResource(R.string.action_send_test_progress),
+                onClick = ::onTestProgressNotification,
             )
 
             // Test a running call

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/tiles/MusicTileScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/tiles/MusicTileScreen.kt
@@ -181,6 +181,14 @@ internal fun MusicTileScreen(
                 onCornerCommit = viewModel::setMusicPlayPauseCornerPercent,
             )
         }
+
+        SettingsToggleCard(
+            shape = RoundedCornerShape(size = 24.dp),
+            title = stringResource(R.string.music_progress_title),
+            description = stringResource(R.string.music_progress_description),
+            checked = settings.showProgress,
+            onCheckedChange = viewModel::setMusicShowProgress,
+        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,8 +54,11 @@
     <string name="status_granted">Enabled</string>
     <string name="status_needed">Tap to enable</string>
     <string name="action_send_test">Send a test notification</string>
+    <string name="action_send_test_progress">Send a test progress notification</string>
     <string name="test_notification_title">Test notification</string>
     <string name="test_notification_text">Expand the island and try the buttons below.</string>
+    <string name="test_progress_notification_title">Downloading file</string>
+    <string name="test_progress_notification_text">Watch the island track the progress.</string>
     <string name="test_notification_action_reply">Reply</string>
     <string name="test_notification_action_mark_read">Mark as read</string>
     <string name="test_notification_reply_hint">Message</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -411,8 +411,7 @@
     <string name="version_beta">Beta</string>
     <string name="changelog_title">What\'s new</string>
     <string name="changelog_subtitle">Newest first. The app is in beta — versions below 0.1.0 were development builds and were never published.</string>
-    <string name="changelog_major">Major features</string>
-    <string name="changelog_minor">Minor features</string>
+    <string name="changelog_features">Features</string>
     <string name="changelog_fixes">Bug fixes</string>
     <string name="profile_permissions_title">Permission details</string>
     <string name="profile_permissions_subtitle">What each permission is for, and what it is not</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -444,4 +444,6 @@
     <string name="import_failed">Import failed</string>
     <string name="bgColor_oled_title">Use OLED black</string>
     <string name="bgColor_oled_desc">Use pure black for lower consuption on OLED screens</string>
+    <string name="music_progress_title">Show progress</string>
+    <string name="music_progress_description">Display a playback progress bar under the controls</string>
 </resources>


### PR DESCRIPTION
In this PR, I added a progress bar to the notifications that have progress data. Now you can see you progress in the cutout as well!

- Added progress bar notifications (expanded and normal),
- Refactored the version changelog (single JSON file -> easier to edit)
- Added progress bar for music (as an option)
- Changed the README and the screenshots