### PR TITLE
Feature/dismiss android notifications

### DIFF
--- a/app/src/main/java/com/ekoehler/expressivecutout/data/BehaviourPreferences.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/data/BehaviourPreferences.kt
@@ -99,6 +99,7 @@ data class BehaviourSettings(
     val centerFillContainers: Boolean = CENTER_FILL_CONTAINERS,
     val centerThemedIcons: Boolean = CENTER_THEMED_ICONS,
     val vibrateOnTap: Boolean = DEFAULT_VIBRATE_ON_TAP,
+    val dismissNotifications: Boolean = DEFAULT_DISMISS_NOTIFICATIONS
 ) {
     companion object {
         const val DEFAULT_CUTOUT_ENABLED = true
@@ -106,8 +107,6 @@ data class BehaviourSettings(
         const val DEFAULT_HIDE_IN_LANDSCAPE = false
         const val DEFAULT_VIBRATE_ON_TAP = true
         val DEFAULT_HORIZONTAL_CUTOUT_MODE = HorizontalCutoutMode.CENTER
-        // Baseline for the island's primary expand/collapse transition; the reveal, background fade
-        // and other animations scale in proportion to it. Matches the tuned defaults in DynamicIsland.
         const val DEFAULT_ANIMATION_DURATION_MS = 220
         val DEFAULT_ANIMATION_STYLE = AnimationStyle.EXPRESSIVE
         val DEFAULT_ANIMATION_SPEED = AnimationSpeed.DEFAULT
@@ -136,6 +135,7 @@ data class BehaviourSettings(
         const val CENTER_SHOW_LABELS = true
         const val CENTER_FILL_CONTAINERS = false
         const val CENTER_THEMED_ICONS = false
+        const val DEFAULT_DISMISS_NOTIFICATIONS = false
     }
 }
 
@@ -201,7 +201,8 @@ class BehaviourPreferences(private val context: Context) : JsonSerializable {
             centerShowLabels = prefs[CENTER_SHOW_LABELS] ?: BehaviourSettings.CENTER_SHOW_LABELS,
             centerFillContainers = prefs[CENTER_FILL_CONTAINERS] ?: BehaviourSettings.CENTER_FILL_CONTAINERS,
             centerThemedIcons = prefs[CENTER_THEMED_ICONS] ?: BehaviourSettings.CENTER_THEMED_ICONS,
-            vibrateOnTap = prefs[VIBRATE_ON_TAP] ?: BehaviourSettings.DEFAULT_VIBRATE_ON_TAP
+            vibrateOnTap = prefs[VIBRATE_ON_TAP] ?: BehaviourSettings.DEFAULT_VIBRATE_ON_TAP,
+            dismissNotifications = prefs[DISMISS_NOTIFICATIONS] ?: BehaviourSettings.DEFAULT_DISMISS_NOTIFICATIONS
         )
     }
 
@@ -355,6 +356,11 @@ class BehaviourPreferences(private val context: Context) : JsonSerializable {
         )
     }
 
+    /** If enabled, dismiss notifications automatically */
+    suspend fun setDismissNotifications(enabled: Boolean) = context.behaviourDataStore.edit {
+        it[DISMISS_NOTIFICATIONS] = enabled
+    }
+
     suspend fun setNormalDurationSeconds(seconds: Int) = context.behaviourDataStore.edit {
         it[NORMAL_SECONDS] = seconds.coerceIn(
             BehaviourSettings.MIN_NORMAL_SECONDS,
@@ -493,5 +499,6 @@ class BehaviourPreferences(private val context: Context) : JsonSerializable {
         val CENTER_FILL_CONTAINERS = booleanPreferencesKey("center_fill_containers")
         val CENTER_THEMED_ICONS = booleanPreferencesKey("center_themed_icons")
         val VIBRATE_ON_TAP = booleanPreferencesKey("vibrate_on_tap")
+        val DISMISS_NOTIFICATIONS = booleanPreferencesKey("dismiss_notifications")
     }
 }

--- a/app/src/main/java/com/ekoehler/expressivecutout/data/BehaviourPreferences.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/data/BehaviourPreferences.kt
@@ -99,7 +99,8 @@ data class BehaviourSettings(
     val centerFillContainers: Boolean = CENTER_FILL_CONTAINERS,
     val centerThemedIcons: Boolean = CENTER_THEMED_ICONS,
     val vibrateOnTap: Boolean = DEFAULT_VIBRATE_ON_TAP,
-    val dismissNotifications: Boolean = DEFAULT_DISMISS_NOTIFICATIONS
+    val dismissNotifications: Boolean = DEFAULT_DISMISS_NOTIFICATIONS,
+    val displayWhileDnd: Boolean = DEFAULT_DISPLAY_WHILE_DND,
 ) {
     companion object {
         const val DEFAULT_CUTOUT_ENABLED = true
@@ -136,6 +137,7 @@ data class BehaviourSettings(
         const val CENTER_FILL_CONTAINERS = false
         const val CENTER_THEMED_ICONS = false
         const val DEFAULT_DISMISS_NOTIFICATIONS = false
+        const val DEFAULT_DISPLAY_WHILE_DND = false
     }
 }
 
@@ -202,7 +204,10 @@ class BehaviourPreferences(private val context: Context) : JsonSerializable {
             centerFillContainers = prefs[CENTER_FILL_CONTAINERS] ?: BehaviourSettings.CENTER_FILL_CONTAINERS,
             centerThemedIcons = prefs[CENTER_THEMED_ICONS] ?: BehaviourSettings.CENTER_THEMED_ICONS,
             vibrateOnTap = prefs[VIBRATE_ON_TAP] ?: BehaviourSettings.DEFAULT_VIBRATE_ON_TAP,
-            dismissNotifications = prefs[DISMISS_NOTIFICATIONS] ?: BehaviourSettings.DEFAULT_DISMISS_NOTIFICATIONS
+            /** If enabled, remove Android notification pop-ups */
+            dismissNotifications = prefs[DISMISS_NOTIFICATIONS] ?: BehaviourSettings.DEFAULT_DISMISS_NOTIFICATIONS,
+            /** If enabled, notification cutout appears even when Do not disturb is enabled */
+            displayWhileDnd = prefs[DISPLAY_WHILE_DND] ?: BehaviourSettings.DEFAULT_DISPLAY_WHILE_DND
         )
     }
 
@@ -241,6 +246,8 @@ class BehaviourPreferences(private val context: Context) : JsonSerializable {
             put("centerFillContainers", s.centerFillContainers)
             put("centerThemedIcons", s.centerThemedIcons)
             put("vibrateOnTap", s.vibrateOnTap)
+            put("dismissNotifications", s.dismissNotifications)
+            put("displayWhileDnd", s.displayWhileDnd)
         }.toString()
     }
 
@@ -304,6 +311,8 @@ class BehaviourPreferences(private val context: Context) : JsonSerializable {
             if (obj.has("centerFillContainers")) it[CENTER_FILL_CONTAINERS] = obj.getBoolean("centerFillContainers")
             if (obj.has("centerThemedIcons")) it[CENTER_THEMED_ICONS] = obj.getBoolean("centerThemedIcons")
             if (obj.has("vibrateOnTap")) it[VIBRATE_ON_TAP] = obj.getBoolean("vibrateOnTap")
+            if (obj.has("dismissNotifications")) it[DISMISS_NOTIFICATIONS] = obj.getBoolean("dismissNotifications")
+            if (obj.has("displayWhileDnd")) it[DISPLAY_WHILE_DND] = obj.getBoolean("displayWhileDnd")
         }
     }
 
@@ -467,6 +476,11 @@ class BehaviourPreferences(private val context: Context) : JsonSerializable {
         it[VIBRATE_ON_TAP] = enabled
     }
 
+    /** Set if notifications appear while Do not disturb is on */
+    suspend fun setDisplayWhileDnd(enabled: Boolean) = context.behaviourDataStore.edit {
+        it[DISPLAY_WHILE_DND] = enabled
+    }
+
     private companion object {
         val CUTOUT_ENABLED = booleanPreferencesKey("cutout_enabled")
         val HIDE_ON_LOCKSCREEN = booleanPreferencesKey("hide_on_lockscreen")
@@ -500,5 +514,6 @@ class BehaviourPreferences(private val context: Context) : JsonSerializable {
         val CENTER_THEMED_ICONS = booleanPreferencesKey("center_themed_icons")
         val VIBRATE_ON_TAP = booleanPreferencesKey("vibrate_on_tap")
         val DISMISS_NOTIFICATIONS = booleanPreferencesKey("dismiss_notifications")
+        val DISPLAY_WHILE_DND = booleanPreferencesKey("display_while_dnd")
     }
 }

--- a/app/src/main/java/com/ekoehler/expressivecutout/notifications/TestNotifier.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/notifications/TestNotifier.kt
@@ -36,6 +36,7 @@ object TestNotifier {
     private const val CHANNEL_ID = "test"
     const val NOTIFICATION_ID = 4711
     const val PROGRESS_NOTIFICATION_ID = 4712
+    const val PLAIN_NOTIFICATION_ID = 4713
 
     /** The notification auto-dismisses after this long so the test never lingers. */
     private const val TIMEOUT_MS = 15_000L
@@ -118,6 +119,43 @@ object TestNotifier {
                 ),
                 // The same glyph the posted notification carries, so the preview goes through the
                 // real "icon from the notification" path rather than the launcher-icon fallback.
+                smallIcon = Icon.createWithResource(context, R.drawable.ic_stat_island),
+            ),
+        )
+    }
+
+    /**
+     * Posts a test notification carrying no actions at all, and mirrors it onto the island. The
+     * counterpart to [send]: the expanded cutout then renders only the header row, which is the
+     * layout where the title has the least room and can ride up under the camera hole. Its text is
+     * deliberately long enough to wrap onto a second line, the case that pushes the header highest.
+     */
+    @SuppressLint("MissingPermission")
+    fun sendPlain(context: Context) {
+        ensureChannel(context)
+
+        val title = context.getString(R.string.test_plain_notification_title)
+        val text = context.getString(R.string.test_plain_notification_text)
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_stat_island)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .setTimeoutAfter(TIMEOUT_MS)
+            .build()
+
+        if (canPost(context)) {
+            NotificationManagerCompat.from(context).notify(PLAIN_NOTIFICATION_ID, notification)
+        }
+
+        IslandEventBus.emit(
+            CutoutSignal.Notification(
+                packageName = context.packageName,
+                title = title,
+                text = text,
                 smallIcon = Icon.createWithResource(context, R.drawable.ic_stat_island),
             ),
         )

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -152,6 +153,7 @@ import com.ekoehler.expressivecutout.data.IconSource
 import com.ekoehler.expressivecutout.data.CALL_MAX_WIDTH_PERCENT
 import com.ekoehler.expressivecutout.data.CALL_MIN_WIDTH_PERCENT
 import com.ekoehler.expressivecutout.data.IslandDimensions
+import com.ekoehler.expressivecutout.data.IslandLayout
 import com.ekoehler.expressivecutout.data.asCallCutout
 import com.ekoehler.expressivecutout.data.MusicButtonStyle
 import com.ekoehler.expressivecutout.data.ReplyInputStyle
@@ -170,8 +172,14 @@ private val PillTextColorDark = Color(0xFF0A0A0A)
 /** Fallback fill for a button asked to be [MusicButtonStyle.filled] before the user picks a colour. */
 private val MusicButtonFilledDefault = Color(0xFFE0E0E0)
 
-// Vertical spacing added around the action row on top of the chip height itself.
-private const val ACTIONS_ROW_SPACING_DP = 14
+// The expanded notification's progress bar: its thickness, and the gap holding it off the text above.
+private const val PROGRESS_BAR_HEIGHT_DP = 8
+private const val PROGRESS_BAR_TOP_GAP_DP = 6
+
+// Vertical spacing added around the action row on top of the chip height itself. Must equal the
+// expanded column's own child spacing, or a notification with actions and one without end up with
+// their header rows at different heights.
+private const val ACTIONS_ROW_SPACING_DP = 12
 
 // How far the island must be dragged upward before a swipe-up collapses it.
 private const val SWIPE_UP_SHRINK_THRESHOLD_DP = 24
@@ -666,6 +674,7 @@ fun DynamicIsland(
                                         event = e,
                                         showActions = showActions,
                                         appearance = appearance,
+                                        collapsedHeightDp = collapsed.heightDp,
                                         replyingTo = replyingTo,
                                         replySent = confirmingSent,
                                         progressData = e.progressData,
@@ -711,6 +720,7 @@ fun IslandPreview(
     expanded: Boolean,
     appearance: AppearanceSettings = AppearanceSettings(),
     showActions: Boolean = true,
+    collapsedHeightDp: Int = IslandLayout.DEFAULT_COLLAPSED.heightDp,
 ) {
     IslandSurface(
         modifier = Modifier.size(width, heightDp.dp),
@@ -729,6 +739,7 @@ fun IslandPreview(
                 event = event,
                 showActions = showActions,
                 appearance = appearance,
+                collapsedHeightDp = collapsedHeightDp,
                 replyingTo = null,
                 replySent = false,
                 onAction = {},
@@ -1228,6 +1239,7 @@ private fun ExpandedContent(
     event: IslandEvent,
     showActions: Boolean,
     appearance: AppearanceSettings,
+    collapsedHeightDp: Int,
     replyingTo: IslandAction?,
     replySent: Boolean,
     progressData: ProgressData? = null,
@@ -1240,12 +1252,21 @@ private fun ExpandedContent(
 ) {
     // The music tile has its own expanded layout (album art + playback controls).
     if (event.media != null) {
-        MediaExpandedContent(event = event, buttonHeightDp = appearance.actionButtonHeightDp)
+        MediaExpandedContent(
+            event = event,
+            buttonHeightDp = appearance.actionButtonHeightDp,
+            collapsedHeightDp = collapsedHeightDp,
+        )
         return
     }
     // The timer tile: icon + ticking remaining time, and its Reset / Add 1 min chips.
     if (event.timer != null) {
-        TimerExpandedContent(event = event, appearance = appearance, onAction = onAction)
+        TimerExpandedContent(
+            event = event,
+            appearance = appearance,
+            collapsedHeightDp = collapsedHeightDp,
+            onAction = onAction,
+        )
         return
     }
     // The assistant tile: icon + text response with vertical scrolling.
@@ -1254,20 +1275,31 @@ private fun ExpandedContent(
             event = event,
             showActions = showActions,
             appearance = appearance,
+            collapsedHeightDp = collapsedHeightDp,
             onDismiss = onDismiss,
             onHeightMeasured = onHeightMeasured,
         )
         return
     }
-    // Content sits in the lower part of the card, leaving the top clear of the camera hole.
-    Box(modifier = Modifier.fillMaxSize().padding(horizontal = 18.dp)) {
+    // Content hugs the card's bottom edge, below a collapsed-pill-height band that keeps the camera
+    // hole clear. The band is a hard floor: a header tall enough to overrun the card (a two-line
+    // detail plus a progress bar) now spills past the bottom instead of riding up under the camera.
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(start = 18.dp, end = 18.dp, top = collapsedHeightDp.dp)
+    ) {
         Column(
             modifier = Modifier
                 .align(Alignment.BottomStart)
                 .padding(bottom = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(ACTIONS_ROW_SPACING_DP.dp),
         ) {
+            // Weighted so the action / reply row below claims its full height first and the header
+            // takes what is left: when the card is too short for both, the text ellipsises rather
+            // than the buttons shrinking.
             Row(
+                modifier = Modifier.weight(1f, fill = false),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(14.dp),
             ) {
@@ -1281,9 +1313,13 @@ private fun ExpandedContent(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
+                    // The only flexible child: the title above and the progress bar below are
+                    // measured at their full size first, so a card too short for all three cuts
+                    // the body text down (and ellipsises it) rather than shaving the bar.
                     event.detail?.let { detail ->
                         Text(
                             text = detail,
+                            modifier = Modifier.weight(1f, fill = false),
                             color = LocalContentColor.current.copy(alpha = 0.70f),
                             fontSize = 12.sp,
                             maxLines = 2,
@@ -1294,9 +1330,19 @@ private fun ExpandedContent(
                     var lastProgressData by remember { mutableStateOf(progressData) }
                     if (progressData != null) lastProgressData = progressData
                     AnimatedVisibility(visible = progressData != null) {
+                        // Material's default indicator is a 4dp hairline at a fixed 240dp width,
+                        // which reads as a stray line on the island. Span the text column and set
+                        // the thickness explicitly — the bar derives its stroke from this height.
+                        // requiredHeight, not height: the latter coerces into whatever the column
+                        // has left over, which is what let a tight card flatten the bar.
+                        val barModifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = PROGRESS_BAR_TOP_GAP_DP.dp)
+                            .requiredHeight(PROGRESS_BAR_HEIGHT_DP.dp)
                         lastProgressData?.let { p ->
                             if (p.isIndeterminate) {
                                 LinearProgressIndicator(
+                                    modifier = barModifier,
                                     color = MaterialTheme.colorScheme.primary,
                                     trackColor = MaterialTheme.colorScheme.primaryContainer,
                                     strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
@@ -1310,6 +1356,7 @@ private fun ExpandedContent(
                                 )
                                 LinearProgressIndicator(
                                     progress = { animatedFraction },
+                                    modifier = barModifier,
                                     color = MaterialTheme.colorScheme.primary,
                                     trackColor = MaterialTheme.colorScheme.primaryContainer,
                                     strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
@@ -1864,19 +1911,25 @@ private fun ReplySendButton(
  * transport handle — is read from [NowPlayingBus] so the controls stay in sync as playback changes.
  */
 @Composable
-private fun MediaExpandedContent(event: IslandEvent, buttonHeightDp: Int) {
+private fun MediaExpandedContent(event: IslandEvent, buttonHeightDp: Int, collapsedHeightDp: Int) {
     val nowPlaying by NowPlayingBus.state.collectAsStateWithLifecycle()
     val albumArt = albumArtFor(event, nowPlaying)
 
-    Box(modifier = Modifier.fillMaxSize().padding(horizontal = 18.dp)) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(start = 18.dp, end = 18.dp, top = collapsedHeightDp.dp)
+    ) {
         Column(
             modifier = Modifier
                 .align(Alignment.BottomStart)
                 .fillMaxWidth()
                 .padding(bottom = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(ACTIONS_ROW_SPACING_DP.dp),
         ) {
+            // Weighted so the transport controls keep their height and the track text gives way.
             Row(
+                modifier = Modifier.weight(1f, fill = false),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(14.dp),
             ) {
@@ -2474,19 +2527,26 @@ private fun CallStatus(onCall: OnCall?) {
 private fun TimerExpandedContent(
     event: IslandEvent,
     appearance: AppearanceSettings,
+    collapsedHeightDp: Int,
     onAction: (IslandAction) -> Unit,
 ) {
     val timer = event.timer ?: return
 
-    Box(modifier = Modifier.fillMaxSize().padding(horizontal = 18.dp)) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(start = 18.dp, end = 18.dp, top = collapsedHeightDp.dp)
+    ) {
         Column(
             modifier = Modifier
                 .align(Alignment.BottomStart)
                 .fillMaxWidth()
                 .padding(bottom = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(ACTIONS_ROW_SPACING_DP.dp),
         ) {
+            // Weighted so the Reset / Add 1 min chips keep their height and the text gives way.
             Row(
+                modifier = Modifier.weight(1f, fill = false),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(14.dp),
             ) {
@@ -2542,6 +2602,7 @@ private fun AssistantExpandedContent(
     event: IslandEvent,
     showActions: Boolean,
     appearance: AppearanceSettings,
+    collapsedHeightDp: Int,
     onDismiss: () -> Unit,
     onHeightMeasured: ((Int) -> Unit)? = null,
 ) {
@@ -2557,7 +2618,7 @@ private fun AssistantExpandedContent(
             .fillMaxWidth()
             .heightIn(max = maxCutoutHeightDp)
             .verticalScroll(rememberScrollState())
-            .padding(horizontal = 18.dp, vertical = 14.dp),
+            .padding(start = 18.dp, end = 18.dp, top = 14.dp + collapsedHeightDp.dp, bottom = 14.dp),
     ) {
         Column(
             modifier = Modifier
@@ -2567,10 +2628,13 @@ private fun AssistantExpandedContent(
                 // into its own fit-to-content target — the loop that made the cutout bob as the answer
                 // streamed in. The content column is laid out with unbounded height, so its reported
                 // height is the answer's true natural height, independent of the surrounding animation.
+                // The reported height must cover the band as well as the 14dp padding above and
+                // below, or the card fits itself to the answer alone and the band pushes the tail
+                // of it out of view.
                 .onGloballyPositioned { coordinates ->
                     val hDp = (coordinates.size.height / density).toInt()
                     if (hDp > 0) {
-                        onHeightMeasured?.invoke(hDp + 28)
+                        onHeightMeasured?.invoke(hDp + 28 + collapsedHeightDp)
                     }
                 },
         ) {

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
@@ -1257,13 +1257,19 @@ class IslandOverlayController(private val context: Context) {
         }
     }
 
+    /**
+     * Tap on the pill: open what it points at. Reading the event before [dismissIsland] clears it,
+     * since settling the notification needs its key.
+     */
     private fun onActivate() {
-        val intent = currentEvent.value?.contentIntent
+        val event = currentEvent.value
+        val intent = event?.contentIntent
         if (isPinnedLiveTile()) {
             dismissJob?.cancel()
             intent?.let(::sendPendingIntent)
             return
         }
+        event?.notificationKey?.let { CutoutNotificationListenerService.settle(it) }
         dismissIsland()
         intent?.let(::sendPendingIntent)
     }
@@ -1288,6 +1294,7 @@ class IslandOverlayController(private val context: Context) {
             action.intent?.let(::sendPendingIntent)
             return
         }
+        currentEvent.value?.notificationKey?.let { CutoutNotificationListenerService.settle(it) }
         dismissIsland()
         action.intent?.let(::sendPendingIntent)
     }
@@ -1299,6 +1306,7 @@ class IslandOverlayController(private val context: Context) {
     private fun onReply(action: IslandAction, text: String) {
         val reply = action.reply ?: return
         val intent = action.intent ?: return
+        currentEvent.value?.notificationKey?.let { CutoutNotificationListenerService.settle(it) }
         dismissIsland()
         val fillIn = Intent()
         val results = Bundle().apply { putCharSequence(reply.resultKey, text) }

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
@@ -157,6 +157,10 @@ class IslandOverlayController(private val context: Context) {
     // The system event currently on the pill, so its auto-dismiss uses that event's own duration
     // override (null while a notification or live tile is showing → the global normal duration).
     private var currentSystemEventType: SystemEventType? = null
+
+    // The notification key the pill last mirrored, so the listener can be told the moment that pill
+    // goes away and a notification it was holding back is due in the panel. See [observeMirroredKey].
+    private var mirroredKey: String? = null
     private var eventDynamicColor: Boolean = false
     private var eventDynamicColorRole: DynamicRole = DynamicRole.PRIMARY
     private var eventDynamicColorOpacity: Float = 1f
@@ -256,9 +260,14 @@ class IslandOverlayController(private val context: Context) {
         observePreviewPin()
         observeSignals()
         observeVisibility()
+        observeMirroredKey()
     }
 
     fun stop() {
+        // The island is going away with a pill still up, so nothing is left to mirror the
+        // notification it was standing in for — hand it back to the panel before the collector that
+        // would normally notice dies with the scope.
+        mirroredKey?.let { CutoutNotificationListenerService.release(it) }
         dismissJob?.cancel()
         windowResizeJob?.cancel()
         runCatching { context.unregisterReceiver(lockReceiver) }
@@ -742,6 +751,26 @@ class IslandOverlayController(private val context: Context) {
     private fun observeVisibility() = scope.launch {
         combine(currentEvent, behaviourState, ::Pair).collect { (event, behaviour) ->
             setTouchable(event != null || (behaviour.showsWhenEmpty && behaviour.cutoutEnabled))
+        }
+    }
+
+    /**
+     * Hand a mirrored notification back to the panel as soon as its pill leaves the island, however
+     * it leaves: the auto-dismiss timer ran out, an expanded pill shrank away, another event took the
+     * island over, the overlay was torn down for the lockscreen. Watching the shown event rather than
+     * hooking each of those paths is what keeps the two in step — nothing can make the pill vanish
+     * without passing through here.
+     *
+     * The user-driven endings (a swipe, a tap, an action) reach the listener first and by their own
+     * route, having already told it to throw the notification away instead; this then finds nothing
+     * left to release.
+     */
+    private fun observeMirroredKey() = scope.launch {
+        currentEvent.collect { event ->
+            val key = event?.notificationKey
+            val previous = mirroredKey
+            if (previous != null && previous != key) CutoutNotificationListenerService.release(previous)
+            mirroredKey = key
         }
     }
 

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
@@ -24,16 +24,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
-import androidx.compose.foundation.layout.Box
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.hapticfeedback.HapticFeedback
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
-import androidx.core.view.HapticFeedbackConstantsCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
@@ -88,7 +81,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import java.lang.reflect.Proxy
-import kotlin.math.abs
 
 /**
  * Owns the single overlay window and drives it from the [IslandEventBus]. Created and

--- a/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
@@ -1,8 +1,11 @@
 package com.ekoehler.expressivecutout.service
 
+import android.app.KeyguardManager
 import android.app.Notification
 import android.content.ComponentName
 import android.content.Context
+import android.os.PowerManager
+import android.os.SystemClock
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
 import android.util.Log
@@ -50,6 +53,12 @@ data class ProgressData(
  * It also lets the overlay dismiss the real notification (not just the pill): the connected
  * instance is published statically so [dismiss] can cancel a notification by key on the user's
  * swipe, mirroring a swipe-away in the shade.
+ *
+ * When the user asked for the shade to be cleared automatically, a mirrored notification is
+ * *snoozed* rather than cancelled — see [snooze]. Cancelling outright loses the notification for
+ * good if nobody happened to be looking at the island while the pill was up; snoozing keeps the
+ * shade quiet during that window and hands the notification back afterwards, so only an explicit
+ * interaction ([dismiss] or [settle]) really destroys it.
  */
 class CutoutNotificationListenerService : NotificationListenerService() {
 
@@ -77,6 +86,17 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     // the main thread and must not wait on a DataStore read. Main-thread only, like the key fields.
     private var dismissNotifications = BehaviourSettings.DEFAULT_DISMISS_NOTIFICATIONS
 
+    // How long a mirrored notification is kept out of the shade, derived from how long the island
+    // actually shows it. Cached alongside [dismissNotifications] and for the same reason.
+    private var snoozeDurationMs = SNOOZE_GRACE_MS
+
+    // Keys we snoozed ourselves mapped to the elapsed-realtime by which the framework's re-post is
+    // due, so that re-post can be told apart from a fresh notification and passed through to the
+    // shade untouched. Timestamped rather than a bare set because notification keys are recycled:
+    // an entry that outlived its window must not swallow the pill of a genuinely new notification
+    // reusing the key. Insertion-ordered and capped at [MAX_TRACKED_SNOOZES]. Main-thread only.
+    private val snoozedUntil = LinkedHashMap<String, Long>()
+
     override fun onListenerConnected() {
         instance = this
         _bound.value = true
@@ -96,18 +116,85 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     }
 
     /**
-     * Keep [dismissNotifications] in step with the stored behaviour settings. The collection outlives
-     * a disconnect (the framework re-uses the same instance on rebind, and a cancelled scope could
-     * not be restarted), so it is only torn down in [onDestroy] and re-entry is a no-op.
+     * Keep [dismissNotifications] and [snoozeDurationMs] in step with the stored behaviour settings.
+     * The collection outlives a disconnect (the framework re-uses the same instance on rebind, and a
+     * cancelled scope could not be restarted), so it is only torn down in [onDestroy] and re-entry is
+     * a no-op.
      */
     private fun observeBehaviour() {
         if (behaviourJob?.isActive == true) return
         behaviourJob = scope.launch {
             behaviourPreferences.settings
-                .map { it.dismissNotifications }
+                .map { it.dismissNotifications to it.snoozeDurationMs() }
                 .distinctUntilChanged()
-                .collect { dismissNotifications = it }
+                .collect { (dismiss, duration) ->
+                    dismissNotifications = dismiss
+                    snoozeDurationMs = duration
+                }
         }
+    }
+
+    /**
+     * How long to hold a notification out of the shade: the island's own pill lifetime plus
+     * [SNOOZE_GRACE_MS], so the shade stays quiet for exactly as long as the pill is up and the
+     * notification lands moments after it fades rather than a minute later. An auto-expanded pill
+     * shows expanded first and only then counts down as a collapsed one, so both spans are counted.
+     */
+    private fun BehaviourSettings.snoozeDurationMs(): Long {
+        val expandedMs = if (notificationsAutoExpand && expandedAutoCollapse) {
+            expandedCollapseSeconds * 1000L
+        } else {
+            0L
+        }
+        return expandedMs + normalDurationSeconds * 1000L + SNOOZE_GRACE_MS
+    }
+
+    /**
+     * Whether the user could plausibly have been looking at the island when a notification landed.
+     * A dark or locked screen never showed the pill, so those notifications are left in the shade
+     * untouched rather than snoozed — there is nothing to have missed them *from*.
+     */
+    private fun isUserPresent(): Boolean {
+        val power = getSystemService(PowerManager::class.java) ?: return false
+        val keyguard = getSystemService(KeyguardManager::class.java) ?: return false
+        return power.isInteractive && !keyguard.isKeyguardLocked
+    }
+
+    /**
+     * Pull [key] out of the shade for [snoozeDurationMs] while the island mirrors it. The framework
+     * re-posts it afterwards, so an unnoticed notification comes back on its own; only an explicit
+     * interaction on the pill ([dismiss] or [settle]) cancels it for good. The key is remembered so
+     * that re-post can be recognised, and only on success — a refused snooze leaves the notification
+     * exactly where it is.
+     */
+    private fun snooze(key: String) {
+        val duration = snoozeDurationMs
+        runCatching { snoozeNotification(key, duration) }
+            .onSuccess { rememberSnooze(key, SystemClock.elapsedRealtime() + duration) }
+            .onFailure { Log.w(TAG, "Failed to snooze notification $key", it) }
+    }
+
+    /**
+     * Track [key] until [dueAt], dropping entries whose window has already passed so a recycled key
+     * can never be mistaken for a snooze that never came back.
+     */
+    private fun rememberSnooze(key: String, dueAt: Long) {
+        val now = SystemClock.elapsedRealtime()
+        snoozedUntil.entries.removeAll { it.value < now }
+        snoozedUntil[key] = dueAt
+        while (snoozedUntil.size > MAX_TRACKED_SNOOZES) {
+            snoozedUntil.remove(snoozedUntil.keys.first())
+        }
+    }
+
+    /**
+     * Whether this post is the framework handing back a notification we snoozed, rather than a new
+     * one. Consumes the entry either way: a key that turns up later than its window is a fresh
+     * notification that happens to reuse it, and deserves its pill.
+     */
+    private fun isSnoozeReturning(key: String): Boolean {
+        val dueAt = snoozedUntil.remove(key) ?: return false
+        return SystemClock.elapsedRealtime() <= dueAt + SNOOZE_GRACE_MS
     }
 
     /**
@@ -161,6 +248,10 @@ class CutoutNotificationListenerService : NotificationListenerService() {
 
         if (!notification.shouldSurface()) return
 
+        // Our own snooze coming back: the island already had its turn with this one, so let it
+        // settle into the shade without popping a second pill moments after the first.
+        if (isSnoozeReturning(notification.key)) return
+
         val extras = notification.notification.extras
         val title = extras?.getCharSequence(Notification.EXTRA_TITLE)?.toString()
         val text = extras?.getCharSequence(Notification.EXTRA_TEXT)?.toString()
@@ -179,8 +270,8 @@ class CutoutNotificationListenerService : NotificationListenerService() {
 
         IslandEventBus.emit(islandEvent)
 
-        if (dismissNotifications) {
-            cancelNotification(notification.key)
+        if (dismissNotifications && isUserPresent()) {
+            snooze(notification.key)
         }
     }
 
@@ -317,6 +408,15 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     companion object {
         private const val TAG = "CutoutNotifListener"
 
+        // Padding on top of the pill's own lifetime, covering the island's animations and giving the
+        // user a moment to reach a pill that has only just faded. Doubles as the slack allowed on a
+        // re-post arriving late.
+        private const val SNOOZE_GRACE_MS = 3_000L
+
+        // Upper bound on [snoozedUntil]. Far above the handful that can be in flight within one
+        // snooze window; purely a guard against runaway growth.
+        private const val MAX_TRACKED_SNOOZES = 64
+
         // The currently connected listener, or null when unbound. Only touched on the main thread
         // (the framework's listener callbacks and the overlay both run there).
         @Volatile
@@ -354,8 +454,22 @@ class CutoutNotificationListenerService : NotificationListenerService() {
          */
         fun dismiss(key: String) {
             val service = instance ?: return
+            service.snoozedUntil.remove(key)
             runCatching { service.cancelNotification(key) }
                 .onFailure { Log.w(TAG, "Failed to cancel notification $key", it) }
+        }
+
+        /**
+         * The user acted on the pill mirroring [key] — tapped it, fired an action, sent a reply — so
+         * a notification we had merely snoozed has served its purpose and must not resurface. Only
+         * touches keys we snoozed ourselves: one the app still owns is the app's to clear, exactly as
+         * before the island got involved.
+         */
+        fun settle(key: String) {
+            val service = instance ?: return
+            if (service.snoozedUntil.remove(key) == null) return
+            runCatching { service.cancelNotification(key) }
+                .onFailure { Log.w(TAG, "Failed to cancel snoozed notification $key", it) }
         }
     }
 }

--- a/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
@@ -6,9 +6,17 @@ import android.content.Context
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
 import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import com.ekoehler.expressivecutout.core.CutoutSignal
 import com.ekoehler.expressivecutout.core.IslandEventBus
 import com.ekoehler.expressivecutout.core.MediaArt
@@ -17,6 +25,8 @@ import com.ekoehler.expressivecutout.core.OnCall
 import com.ekoehler.expressivecutout.core.OnCallBus
 import com.ekoehler.expressivecutout.core.RunningTimer
 import com.ekoehler.expressivecutout.core.RunningTimerBus
+import com.ekoehler.expressivecutout.data.BehaviourPreferences
+import com.ekoehler.expressivecutout.data.BehaviourSettings
 import com.ekoehler.expressivecutout.events.CallNotificationParser
 import com.ekoehler.expressivecutout.events.TimerNotificationParser
 import com.ekoehler.expressivecutout.overlay.loadImageBitmapOrNull
@@ -57,9 +67,20 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     // Key of the assistant notification currently driving the assistant tile.
     private var currentAssistantKey: String? = null
 
+    private val scope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
+
+    private val behaviourPreferences by lazy { BehaviourPreferences(this) }
+
+    private var behaviourJob: Job? = null
+
+    // Mirror of BehaviourSettings.dismissNotifications, cached because onNotificationPosted runs on
+    // the main thread and must not wait on a DataStore read. Main-thread only, like the key fields.
+    private var dismissNotifications = BehaviourSettings.DEFAULT_DISMISS_NOTIFICATIONS
+
     override fun onListenerConnected() {
         instance = this
         _bound.value = true
+        observeBehaviour()
     }
 
     override fun onListenerDisconnected() {
@@ -70,7 +91,23 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     override fun onDestroy() {
         if (instance === this) instance = null
         _bound.value = false
+        scope.cancel()
         super.onDestroy()
+    }
+
+    /**
+     * Keep [dismissNotifications] in step with the stored behaviour settings. The collection outlives
+     * a disconnect (the framework re-uses the same instance on rebind, and a cancelled scope could
+     * not be restarted), so it is only torn down in [onDestroy] and re-entry is a no-op.
+     */
+    private fun observeBehaviour() {
+        if (behaviourJob?.isActive == true) return
+        behaviourJob = scope.launch {
+            behaviourPreferences.settings
+                .map { it.dismissNotifications }
+                .distinctUntilChanged()
+                .collect { dismissNotifications = it }
+        }
     }
 
     /**
@@ -128,20 +165,23 @@ class CutoutNotificationListenerService : NotificationListenerService() {
         val title = extras?.getCharSequence(Notification.EXTRA_TITLE)?.toString()
         val text = extras?.getCharSequence(Notification.EXTRA_TEXT)?.toString()
         val progress = getProgressDataOrNull(sbn)
-
-        IslandEventBus.emit(
-            CutoutSignal.Notification(
-                packageName = notification.packageName,
-                title = title,
-                text = text,
-                key = notification.key,
-                contentIntent = notification.notification.contentIntent,
-                actions = notification.notification.surfaceableActions(),
-                largeIcon = notification.notification.getLargeIcon(),
-                smallIcon = notification.notification.smallIcon,
-                progressData = progress
-            ),
+        val islandEvent = CutoutSignal.Notification(
+            packageName = notification.packageName,
+            title = title,
+            text = text,
+            key = notification.key,
+            contentIntent = notification.notification.contentIntent,
+            actions = notification.notification.surfaceableActions(),
+            largeIcon = notification.notification.getLargeIcon(),
+            smallIcon = notification.notification.smallIcon,
+            progressData = progress
         )
+
+        IslandEventBus.emit(islandEvent)
+
+        if (dismissNotifications) {
+            cancelNotification(notification.key)
+        }
     }
 
     override fun onNotificationRemoved(sbn: StatusBarNotification?) {

--- a/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
@@ -216,14 +216,35 @@ class CutoutNotificationListenerService : NotificationListenerService() {
      * on the pill never reaches the panel at all. The hold lasts until the island says what became of
      * the pill ([releaseHeld] or [discard]); [MAX_HOLD_MS] is only a ceiling, so a notification we
      * never hear about again — the overlay was torn down, the listener died — still comes back on its
-     * own rather than being lost. Tracked only on success: a refused snooze leaves the notification
-     * exactly where it is.
+     * own rather than being lost. Tracked whenever the request reaches the framework, which is as much
+     * as [snooze] can tell us; [verifyHold] is what proves the hold was actually taken.
      */
     private fun hold(key: String) {
         if (!snooze(key, MAX_HOLD_MS)) return
         returning.remove(key)
         pendingCancel.remove(key)
         held.track(key, SystemClock.elapsedRealtime() + MAX_HOLD_MS)
+        verifyHold(key)
+    }
+
+    /**
+     * Report whether the framework actually took the hold on [key]. snoozeNotification() returns void
+     * and refuses silently, so the only proof is whether the notification has left the active list a
+     * moment later.
+     */
+    private fun verifyHold(key: String) {
+        if (!TRACE_HOLDS) return
+        scope.launch {
+            delay(HOLD_CHECK_DELAY_MS)
+            val active = runCatching { getActiveNotifications(arrayOf(key)) }
+                .onFailure { Log.w(TAG, "getActiveNotifications failed for $key", it) }
+                .getOrNull() ?: return@launch
+            if (active.isNotEmpty()) {
+                Log.w(TAG, "Snooze refused: $key still active after ${HOLD_CHECK_DELAY_MS}ms")
+            } else {
+                Log.i(TAG, "Snooze held: $key")
+            }
+        }
     }
 
     /**
@@ -275,16 +296,22 @@ class CutoutNotificationListenerService : NotificationListenerService() {
      * second the fetch-back takes.
      *
      * That hint is global, so a notification from another app landing inside the window is silenced
-     * with it — the window is only [RETURN_DELAY_MS] wide and closes the moment the re-post lands, or
-     * on [unmuteJob] if it never does. Incoming calls are never affected: the framework exempts
+     * with it — the window normally closes the moment the re-post lands, and only falls back to
+     * [unmuteJob] if it never does. Incoming calls are never affected: the framework exempts
      * ringtones from this hint by design.
+     *
+     * The fallback waits out the same grace [consume] allows, not a shorter one of its own: the
+     * framework's snooze alarm routinely runs late (measured around 850ms against a [RETURN_DELAY_MS]
+     * of 500), and a mute that expired before that grace did would leave a band where a re-post is
+     * still recognised as ours — so it raises no second pill — yet arrives loud, which is precisely
+     * the alert the hold exists to prevent.
      */
     private fun muteReturn() {
         mutedReturns++
         if (mutedReturns == 1) setEffectsMuted(true)
         unmuteJob?.cancel()
         unmuteJob = scope.launch {
-            delay(RETURN_DELAY_MS + MUTE_GRACE_MS)
+            delay(RETURN_DELAY_MS + SNOOZE_GRACE_MS)
             mutedReturns = 0
             setEffectsMuted(false)
         }
@@ -310,7 +337,11 @@ class CutoutNotificationListenerService : NotificationListenerService() {
             .onFailure { Log.w(TAG, "Failed to request listener hints", it) }
     }
 
-    /** Snooze [key] for [durationMs], reporting whether the framework took it. */
+    /**
+     * Snooze [key] for [durationMs], reporting whether the request reached the framework. Not whether
+     * the framework acted on it: snoozeNotification() returns nothing and refuses silently, so only
+     * the notification's absence from the active list proves a hold was taken — see [verifyHold].
+     */
     private fun snooze(key: String, durationMs: Long): Boolean =
         runCatching { snoozeNotification(key, durationMs) }
             .onFailure { Log.w(TAG, "Failed to snooze notification $key", it) }
@@ -571,6 +602,16 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     companion object {
         private const val TAG = "CutoutNotifListener"
 
+        // Flip to trace every hold to logcat under [TAG]. Off in normal builds: the check behind it
+        // costs a round trip to the framework per notification, and is only ever needed while
+        // investigating the hold itself.
+        private const val TRACE_HOLDS = false
+
+        // How long after a hold the notification is checked for having actually left the active list.
+        // Long enough for the framework to have processed the snooze, short enough to stay inside the
+        // pill's own lifetime. Only used when [TRACE_HOLDS] is on.
+        private const val HOLD_CHECK_DELAY_MS = 400L
+
         // Ceiling on a hold, for the case where the island never reports back — the overlay was torn
         // down, the accessibility service died — so a notification is never kept from the panel for
         // longer than this no matter what. Well past any pill the user could plausibly leave up,
@@ -582,12 +623,9 @@ class CutoutNotificationListenerService : NotificationListenerService() {
         // framework's alarm can actually honour.
         private const val RETURN_DELAY_MS = 500L
 
-        // How long past the expected re-post the effects mute is allowed to last before it is dropped
-        // regardless. Only ever reached when a fetch-back doesn't arrive at all — a landing re-post
-        // closes the window itself, well inside this.
-        private const val MUTE_GRACE_MS = 1_000L
-
-        // Slack allowed on a re-post arriving later than its window says it should.
+        // Slack allowed on a re-post arriving later than its window says it should. Also bounds how
+        // long the effects mute may last, so the two can never disagree about whether a late re-post
+        // is still ours — see [muteReturn].
         private const val SNOOZE_GRACE_MS = 3_000L
 
         // Upper bound on [held], [returning] and [pendingCancel]. Far above the handful that can be

--- a/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import com.ekoehler.expressivecutout.core.CutoutSignal
 import com.ekoehler.expressivecutout.core.IslandEventBus
@@ -86,6 +85,10 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     // the main thread and must not wait on a DataStore read. Main-thread only, like the key fields.
     private var dismissNotifications = BehaviourSettings.DEFAULT_DISMISS_NOTIFICATIONS
 
+    // Mirror of BehaviourSettings.displayWhileDnd, cached alongside [dismissNotifications] and for
+    // the same reason. Main-thread only, like the key fields.
+    private var displayWhileDnd = BehaviourSettings.DEFAULT_DISPLAY_WHILE_DND
+
     // How long a mirrored notification is kept out of the shade, derived from how long the island
     // actually shows it. Cached alongside [dismissNotifications] and for the same reason.
     private var snoozeDurationMs = SNOOZE_GRACE_MS
@@ -125,11 +128,11 @@ class CutoutNotificationListenerService : NotificationListenerService() {
         if (behaviourJob?.isActive == true) return
         behaviourJob = scope.launch {
             behaviourPreferences.settings
-                .map { it.dismissNotifications to it.snoozeDurationMs() }
                 .distinctUntilChanged()
-                .collect { (dismiss, duration) ->
-                    dismissNotifications = dismiss
-                    snoozeDurationMs = duration
+                .collect { settings ->
+                    dismissNotifications = settings.dismissNotifications
+                    snoozeDurationMs = settings.snoozeDurationMs()
+                    displayWhileDnd = settings.displayWhileDnd
                 }
         }
     }
@@ -147,6 +150,27 @@ class CutoutNotificationListenerService : NotificationListenerService() {
             0L
         }
         return expandedMs + normalDurationSeconds * 1000L + SNOOZE_GRACE_MS
+    }
+
+    /**
+     * Whether Do Not Disturb should keep this notification off the island. Reads the effective
+     * interruption filter rather than Settings.Global.zen_mode: that global only tracks the manual
+     * toggle, so a filter in force through a schedule, an automatic rule or a Mode leaves it at zero
+     * and the gate never closes. The filter is matched explicitly because
+     * [INTERRUPTION_FILTER_UNKNOWN] sorts *below* [INTERRUPTION_FILTER_ALL] — "not yet known" must
+     * not read as either "no DND" or "DND on".
+     *
+     * Calls and timers are deliberately handled before this check ever runs: they break through DND
+     * by design, and an island that hid an incoming call would be worse than no island at all.
+     */
+    private fun suppressedByDnd(): Boolean {
+        if (displayWhileDnd) return false
+        return when (currentInterruptionFilter) {
+            INTERRUPTION_FILTER_PRIORITY,
+            INTERRUPTION_FILTER_ALARMS,
+            INTERRUPTION_FILTER_NONE -> true
+            else -> false
+        }
     }
 
     /**
@@ -198,13 +222,6 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     }
 
     /**
-     * Checks if the notification is a progress one
-     */
-    fun isProgressNotification(sbn: StatusBarNotification): Boolean {
-        return getProgressDataOrNull(sbn) != null
-    }
-
-    /**
      * Returns progress data from a notification (or null if no progress).
      *
      * The progress extras are written by [Notification.Builder] for every notification, whether or
@@ -247,6 +264,8 @@ class CutoutNotificationListenerService : NotificationListenerService() {
         notification.publishMediaArt()
 
         if (!notification.shouldSurface()) return
+
+        if (suppressedByDnd()) return
 
         // Our own snooze coming back: the island already had its turn with this one, so let it
         // settle into the shade without popping a second pill moments after the first.

--- a/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
@@ -47,7 +47,8 @@ data class ProgressData(
 /**
  * Mirrors freshly posted notifications onto the island. It keeps only the posting package,
  * title and text (shown when the island is expanded) and filters out noise (its own posts,
- * group summaries, and ongoing/system-managed notifications).
+ * group summaries, and ongoing/system-managed notifications — except when one carries a live
+ * progress bar, which the progress tile is there to show).
  *
  * It also lets the overlay dismiss the real notification (not just the pill): the connected
  * instance is published statically so [dismiss] can cancel a notification by key on the user's
@@ -289,7 +290,10 @@ class CutoutNotificationListenerService : NotificationListenerService() {
 
         IslandEventBus.emit(islandEvent)
 
-        if (dismissNotifications && isUserPresent()) {
+        // Never snooze a transfer still running: it re-posts on every step, so snoozing would fight
+        // the download for the shade and hide the very bar the user wants to watch. Its completion
+        // notice carries no progress, so that one auto-dismisses normally.
+        if (dismissNotifications && progress == null && isUserPresent()) {
             snooze(notification.key)
         }
     }
@@ -419,9 +423,14 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     private fun StatusBarNotification.shouldSurface(): Boolean {
         if (packageName == this@CutoutNotificationListenerService.packageName) return false
         val flags = notification.flags
-        val isSummary = flags and Notification.FLAG_GROUP_SUMMARY != 0
+        if (flags and Notification.FLAG_GROUP_SUMMARY != 0) return false
+        // A transfer in flight (a Chrome download, an upload) is ongoing and unclearable by design,
+        // which the general filter below drops. A live progress bar is precisely what the progress
+        // tile exists to show, so carrying one overrides both tests — persistent foreground-service
+        // notices without a bar (a VPN, a sync service) stay filtered out as before.
+        if (getProgressDataOrNull(this) != null) return true
         val isOngoing = flags and Notification.FLAG_ONGOING_EVENT != 0
-        return isClearable && !isSummary && !isOngoing
+        return isClearable && !isOngoing
     }
 
     companion object {

--- a/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -85,6 +86,8 @@ class CutoutNotificationListenerService : NotificationListenerService() {
 
     private val behaviourPreferences by lazy { BehaviourPreferences(this) }
 
+    private val alerter by lazy { NotificationAlerter(this) }
+
     private var behaviourJob: Job? = null
 
     // Mirror of BehaviourSettings.dismissNotifications, cached because onNotificationPosted runs on
@@ -108,6 +111,15 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     // Keys the user killed on the pill, awaiting the re-post that lets us cancel them. Mirrors [held].
     private val pendingCancel = LinkedHashMap<String, Long>()
 
+    // How many fetch-backs are in flight with notification effects muted. The hint behind that mute
+    // is global and has no per-notification form, so it is raised once and dropped only when the last
+    // of them has landed. Main-thread only, like the maps above.
+    private var mutedReturns = 0
+
+    // Closes the mute window even if a fetch-back never lands, so a refused or lost re-post can't
+    // leave the device silent.
+    private var unmuteJob: Job? = null
+
     override fun onListenerConnected() {
         instance = this
         _bound.value = true
@@ -122,6 +134,10 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     override fun onDestroy() {
         if (instance === this) instance = null
         _bound.value = false
+        // Drop the effects mute by hand before the job that would have done it dies with the scope:
+        // a fetch-back caught mid-flight by a teardown must not leave the device silent.
+        if (mutedReturns > 0) setEffectsMuted(false)
+        alerter.stop()
         scope.cancel()
         super.onDestroy()
     }
@@ -177,6 +193,25 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     }
 
     /**
+     * Ring and buzz for a notification the island is taking over, standing in for the alert the hold
+     * is about to cut short. Only ever for a notification we are actually holding — one left in the
+     * shade still has its own alert, and doubling it would be worse than the silence this fixes.
+     *
+     * Whether Do Not Disturb (or a priority rule, or the app's own quieting) would have let this one
+     * make a sound at all is the framework's verdict, taken off the ranking rather than guessed at
+     * again here. The ranking is read on this thread — it is only valid on it — and only the playback
+     * is handed off, since opening a ringtone touches the disk.
+     */
+    private fun alertFor(sbn: StatusBarNotification) {
+        val ranking = Ranking()
+        if (currentRanking?.getRanking(sbn.key, ranking) != true) return
+        if (!ranking.matchesInterruptionFilter()) return
+        val channel = ranking.channel
+        val importance = ranking.importance
+        scope.launch(Dispatchers.IO) { alerter.alert(channel, importance) }
+    }
+
+    /**
      * Pull [key] out of the shade while the island mirrors it, so a notification the user deals with
      * on the pill never reaches the panel at all. The hold lasts until the island says what became of
      * the pill ([releaseHeld] or [discard]); [MAX_HOLD_MS] is only a ceiling, so a notification we
@@ -201,6 +236,7 @@ class CutoutNotificationListenerService : NotificationListenerService() {
      */
     private fun releaseHeld(key: String) {
         val ceiling = held.remove(key) ?: return
+        muteReturn()
         snooze(key, RETURN_DELAY_MS)
         returning.track(key, ceiling)
     }
@@ -224,8 +260,54 @@ class CutoutNotificationListenerService : NotificationListenerService() {
             return
         }
         returning.remove(key)
+        muteReturn()
         snooze(key, RETURN_DELAY_MS)
         pendingCancel.track(key, ceiling)
+    }
+
+    /**
+     * Silence notification sound and vibration while a fetch-back is in flight. The framework treats
+     * the re-post of a snoozed notification as a brand-new post and alerts for it all over again —
+     * its repost alarm asks for no mute — so a notification the user has already been shown on the
+     * island would ring them a second time on its way to the panel, and one they threw away would
+     * ring on its way to being cancelled. A listener cannot ask for a single notification to arrive
+     * quietly, so the effects hint (the one lever it does have) is raised for the fraction of a
+     * second the fetch-back takes.
+     *
+     * That hint is global, so a notification from another app landing inside the window is silenced
+     * with it — the window is only [RETURN_DELAY_MS] wide and closes the moment the re-post lands, or
+     * on [unmuteJob] if it never does. Incoming calls are never affected: the framework exempts
+     * ringtones from this hint by design.
+     */
+    private fun muteReturn() {
+        mutedReturns++
+        if (mutedReturns == 1) setEffectsMuted(true)
+        unmuteJob?.cancel()
+        unmuteJob = scope.launch {
+            delay(RETURN_DELAY_MS + MUTE_GRACE_MS)
+            mutedReturns = 0
+            setEffectsMuted(false)
+        }
+    }
+
+    /**
+     * A fetch-back landed, so it no longer needs the shade kept quiet. Safe to unmute the moment we
+     * hear about the re-post: the framework decides whether to alert while still holding the lock our
+     * request has to take, so it can never slip in ahead of that decision.
+     */
+    private fun endMutedReturn() {
+        if (mutedReturns == 0) return
+        mutedReturns--
+        if (mutedReturns > 0) return
+        unmuteJob?.cancel()
+        unmuteJob = null
+        setEffectsMuted(false)
+    }
+
+    private fun setEffectsMuted(muted: Boolean) {
+        val hints = if (muted) HINT_HOST_DISABLE_NOTIFICATION_EFFECTS else 0
+        runCatching { requestListenerHints(hints) }
+            .onFailure { Log.w(TAG, "Failed to request listener hints", it) }
     }
 
     /** Snooze [key] for [durationMs], reporting whether the framework took it. */
@@ -309,12 +391,16 @@ class CutoutNotificationListenerService : NotificationListenerService() {
         // one is already spoken for.
         if (pendingCancel.consume(notification.key)) {
             cancel(notification.key)
+            endMutedReturn()
             return
         }
 
         // Likewise, but the pill merely ran out: the island already had its turn with this one, so
         // let it settle into the panel without popping a second pill.
-        if (returning.consume(notification.key)) return
+        if (returning.consume(notification.key)) {
+            endMutedReturn()
+            return
+        }
 
         if (!notification.shouldSurface()) return
 
@@ -342,6 +428,7 @@ class CutoutNotificationListenerService : NotificationListenerService() {
         // the download for the shade and hide the very bar the user wants to watch. Its completion
         // notice carries no progress, so that one auto-dismisses normally.
         if (dismissNotifications && progress == null && isUserPresent()) {
+            alertFor(notification)
             hold(notification.key)
         }
     }
@@ -494,6 +581,11 @@ class CutoutNotificationListenerService : NotificationListenerService() {
         // lands as the pill fades rather than noticeably after it, long enough to be a delay the
         // framework's alarm can actually honour.
         private const val RETURN_DELAY_MS = 500L
+
+        // How long past the expected re-post the effects mute is allowed to last before it is dropped
+        // regardless. Only ever reached when a fetch-back doesn't arrive at all — a landing re-post
+        // closes the window itself, well inside this.
+        private const val MUTE_GRACE_MS = 1_000L
 
         // Slack allowed on a re-post arriving later than its window says it should.
         private const val SNOOZE_GRACE_MS = 3_000L

--- a/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
@@ -54,11 +54,16 @@ data class ProgressData(
  * instance is published statically so [dismiss] can cancel a notification by key on the user's
  * swipe, mirroring a swipe-away in the shade.
  *
- * When the user asked for the shade to be cleared automatically, a mirrored notification is
- * *snoozed* rather than cancelled — see [snooze]. Cancelling outright loses the notification for
- * good if nobody happened to be looking at the island while the pill was up; snoozing keeps the
- * shade quiet during that window and hands the notification back afterwards, so only an explicit
- * interaction ([dismiss] or [settle]) really destroys it.
+ * When the user asked for the shade to be cleared automatically, a mirrored notification is *held*
+ * out of the shade (snoozed) rather than cancelled — see [hold]. Cancelling outright loses the
+ * notification for good if nobody happened to be looking at the island while the pill was up, so the
+ * island decides its fate instead: [releaseHeld] hands it back the moment the pill fades, while
+ * [discard] destroys it because the user acted on the pill. With the setting off, nothing here ever
+ * touches the real notification.
+ *
+ * A held notification is out of the framework's active list, so it cannot be cancelled by key while
+ * the hold lasts. Both endings therefore re-snooze it for [RETURN_DELAY_MS] to fetch it back, and act
+ * on the re-post: letting it settle into the shade silently, or cancelling it then.
  */
 class CutoutNotificationListenerService : NotificationListenerService() {
 
@@ -90,16 +95,18 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     // the same reason. Main-thread only, like the key fields.
     private var displayWhileDnd = BehaviourSettings.DEFAULT_DISPLAY_WHILE_DND
 
-    // How long a mirrored notification is kept out of the shade, derived from how long the island
-    // actually shows it. Cached alongside [dismissNotifications] and for the same reason.
-    private var snoozeDurationMs = SNOOZE_GRACE_MS
+    // Keys currently held out of the shade because the island is showing them, mapped to the
+    // elapsed-realtime at which the hold expires on its own. Timestamped rather than a bare set
+    // because notification keys are recycled: an entry that outlived its window must not swallow the
+    // pill of a genuinely new notification reusing the key. Insertion-ordered and capped at
+    // [MAX_TRACKED_KEYS]. Main-thread only, like the key fields.
+    private val held = LinkedHashMap<String, Long>()
 
-    // Keys we snoozed ourselves mapped to the elapsed-realtime by which the framework's re-post is
-    // due, so that re-post can be told apart from a fresh notification and passed through to the
-    // shade untouched. Timestamped rather than a bare set because notification keys are recycled:
-    // an entry that outlived its window must not swallow the pill of a genuinely new notification
-    // reusing the key. Insertion-ordered and capped at [MAX_TRACKED_SNOOZES]. Main-thread only.
-    private val snoozedUntil = LinkedHashMap<String, Long>()
+    // Keys handed back to the shade, awaiting the re-post that puts them there. Mirrors [held].
+    private val returning = LinkedHashMap<String, Long>()
+
+    // Keys the user killed on the pill, awaiting the re-post that lets us cancel them. Mirrors [held].
+    private val pendingCancel = LinkedHashMap<String, Long>()
 
     override fun onListenerConnected() {
         instance = this
@@ -120,7 +127,7 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     }
 
     /**
-     * Keep [dismissNotifications] and [snoozeDurationMs] in step with the stored behaviour settings.
+     * Keep [dismissNotifications] and [displayWhileDnd] in step with the stored behaviour settings.
      * The collection outlives a disconnect (the framework re-uses the same instance on rebind, and a
      * cancelled scope could not be restarted), so it is only torn down in [onDestroy] and re-entry is
      * a no-op.
@@ -132,25 +139,9 @@ class CutoutNotificationListenerService : NotificationListenerService() {
                 .distinctUntilChanged()
                 .collect { settings ->
                     dismissNotifications = settings.dismissNotifications
-                    snoozeDurationMs = settings.snoozeDurationMs()
                     displayWhileDnd = settings.displayWhileDnd
                 }
         }
-    }
-
-    /**
-     * How long to hold a notification out of the shade: the island's own pill lifetime plus
-     * [SNOOZE_GRACE_MS], so the shade stays quiet for exactly as long as the pill is up and the
-     * notification lands moments after it fades rather than a minute later. An auto-expanded pill
-     * shows expanded first and only then counts down as a collapsed one, so both spans are counted.
-     */
-    private fun BehaviourSettings.snoozeDurationMs(): Long {
-        val expandedMs = if (notificationsAutoExpand && expandedAutoCollapse) {
-            expandedCollapseSeconds * 1000L
-        } else {
-            0L
-        }
-        return expandedMs + normalDurationSeconds * 1000L + SNOOZE_GRACE_MS
     }
 
     /**
@@ -186,39 +177,87 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     }
 
     /**
-     * Pull [key] out of the shade for [snoozeDurationMs] while the island mirrors it. The framework
-     * re-posts it afterwards, so an unnoticed notification comes back on its own; only an explicit
-     * interaction on the pill ([dismiss] or [settle]) cancels it for good. The key is remembered so
-     * that re-post can be recognised, and only on success — a refused snooze leaves the notification
+     * Pull [key] out of the shade while the island mirrors it, so a notification the user deals with
+     * on the pill never reaches the panel at all. The hold lasts until the island says what became of
+     * the pill ([releaseHeld] or [discard]); [MAX_HOLD_MS] is only a ceiling, so a notification we
+     * never hear about again — the overlay was torn down, the listener died — still comes back on its
+     * own rather than being lost. Tracked only on success: a refused snooze leaves the notification
      * exactly where it is.
      */
-    private fun snooze(key: String) {
-        val duration = snoozeDurationMs
-        runCatching { snoozeNotification(key, duration) }
-            .onSuccess { rememberSnooze(key, SystemClock.elapsedRealtime() + duration) }
+    private fun hold(key: String) {
+        if (!snooze(key, MAX_HOLD_MS)) return
+        returning.remove(key)
+        pendingCancel.remove(key)
+        held.track(key, SystemClock.elapsedRealtime() + MAX_HOLD_MS)
+    }
+
+    /**
+     * The pill mirroring [key] faded on its own, so the notification has had its turn on the island
+     * and belongs in the panel now: cut the hold short and let the re-post through silently. Only
+     * touches keys we hold — one the user already acted on, or that was never held, is not ours to
+     * bring back. Kept tracked until the original ceiling rather than the short delay, so a re-post
+     * the framework drags its feet over (or one that only arrives when the ceiling fires, because the
+     * fetch-back was refused) is still recognised as ours and doesn't pop a second pill.
+     */
+    private fun releaseHeld(key: String) {
+        val ceiling = held.remove(key) ?: return
+        snooze(key, RETURN_DELAY_MS)
+        returning.track(key, ceiling)
+    }
+
+    /**
+     * The user acted on the pill mirroring [key] — swiped it away, tapped it, fired an action — so
+     * the notification must never reach the panel. A held notification is out of the framework's
+     * active list and cannot be cancelled by key, so it is fetched back first and cancelled the
+     * moment it lands, before any of it is mirrored.
+     *
+     * A key we never held is cancelled outright, but only when the user asked for notifications to be
+     * dismissed automatically and this was a swipe: with that setting off the shade is not ours to
+     * touch, and a tap or an action ([onlyIfHeld]) leaves the notification to the app that owns it,
+     * exactly as tapping it in the shade would.
+     */
+    private fun discard(key: String, onlyIfHeld: Boolean) {
+        val ceiling = held.remove(key)
+        if (ceiling == null) {
+            if (onlyIfHeld || !dismissNotifications) return
+            cancel(key)
+            return
+        }
+        returning.remove(key)
+        snooze(key, RETURN_DELAY_MS)
+        pendingCancel.track(key, ceiling)
+    }
+
+    /** Snooze [key] for [durationMs], reporting whether the framework took it. */
+    private fun snooze(key: String, durationMs: Long): Boolean =
+        runCatching { snoozeNotification(key, durationMs) }
             .onFailure { Log.w(TAG, "Failed to snooze notification $key", it) }
+            .isSuccess
+
+    /** Cancel [key] from the system, exactly as swiping it away in the shade would. */
+    private fun cancel(key: String) {
+        runCatching { cancelNotification(key) }
+            .onFailure { Log.w(TAG, "Failed to cancel notification $key", it) }
     }
 
     /**
      * Track [key] until [dueAt], dropping entries whose window has already passed so a recycled key
-     * can never be mistaken for a snooze that never came back.
+     * can never be mistaken for one still in flight, and capping growth at [MAX_TRACKED_KEYS].
      */
-    private fun rememberSnooze(key: String, dueAt: Long) {
+    private fun LinkedHashMap<String, Long>.track(key: String, dueAt: Long) {
         val now = SystemClock.elapsedRealtime()
-        snoozedUntil.entries.removeAll { it.value < now }
-        snoozedUntil[key] = dueAt
-        while (snoozedUntil.size > MAX_TRACKED_SNOOZES) {
-            snoozedUntil.remove(snoozedUntil.keys.first())
-        }
+        entries.removeAll { it.value + SNOOZE_GRACE_MS < now }
+        put(key, dueAt)
+        while (size > MAX_TRACKED_KEYS) remove(keys.first())
     }
 
     /**
-     * Whether this post is the framework handing back a notification we snoozed, rather than a new
-     * one. Consumes the entry either way: a key that turns up later than its window is a fresh
-     * notification that happens to reuse it, and deserves its pill.
+     * Take [key] out of this map, reporting whether it was still within its window. Consumes the
+     * entry either way: a key that turns up later than that is a fresh notification which happens to
+     * reuse it, and deserves its pill.
      */
-    private fun isSnoozeReturning(key: String): Boolean {
-        val dueAt = snoozedUntil.remove(key) ?: return false
+    private fun LinkedHashMap<String, Long>.consume(key: String): Boolean {
+        val dueAt = remove(key) ?: return false
         return SystemClock.elapsedRealtime() <= dueAt + SNOOZE_GRACE_MS
     }
 
@@ -264,13 +303,22 @@ class CutoutNotificationListenerService : NotificationListenerService() {
         // Music
         notification.publishMediaArt()
 
+        // A held notification coming back. The user acted on its pill, so now that the framework has
+        // handed it back — and it can be cancelled at all — kill it before any of it reaches the
+        // panel. Checked ahead of every filter below: whatever the island would make of it now, this
+        // one is already spoken for.
+        if (pendingCancel.consume(notification.key)) {
+            cancel(notification.key)
+            return
+        }
+
+        // Likewise, but the pill merely ran out: the island already had its turn with this one, so
+        // let it settle into the panel without popping a second pill.
+        if (returning.consume(notification.key)) return
+
         if (!notification.shouldSurface()) return
 
         if (suppressedByDnd()) return
-
-        // Our own snooze coming back: the island already had its turn with this one, so let it
-        // settle into the shade without popping a second pill moments after the first.
-        if (isSnoozeReturning(notification.key)) return
 
         val extras = notification.notification.extras
         val title = extras?.getCharSequence(Notification.EXTRA_TITLE)?.toString()
@@ -290,11 +338,11 @@ class CutoutNotificationListenerService : NotificationListenerService() {
 
         IslandEventBus.emit(islandEvent)
 
-        // Never snooze a transfer still running: it re-posts on every step, so snoozing would fight
+        // Never hold a transfer still running: it re-posts on every step, so holding it would fight
         // the download for the shade and hide the very bar the user wants to watch. Its completion
         // notice carries no progress, so that one auto-dismisses normally.
         if (dismissNotifications && progress == null && isUserPresent()) {
-            snooze(notification.key)
+            hold(notification.key)
         }
     }
 
@@ -436,14 +484,23 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     companion object {
         private const val TAG = "CutoutNotifListener"
 
-        // Padding on top of the pill's own lifetime, covering the island's animations and giving the
-        // user a moment to reach a pill that has only just faded. Doubles as the slack allowed on a
-        // re-post arriving late.
+        // Ceiling on a hold, for the case where the island never reports back — the overlay was torn
+        // down, the accessibility service died — so a notification is never kept from the panel for
+        // longer than this no matter what. Well past any pill the user could plausibly leave up,
+        // since the island normally ends the hold itself long before this fires.
+        private const val MAX_HOLD_MS = 60_000L
+
+        // How long the fetch-back at the end of a hold takes. Short enough that the notification
+        // lands as the pill fades rather than noticeably after it, long enough to be a delay the
+        // framework's alarm can actually honour.
+        private const val RETURN_DELAY_MS = 500L
+
+        // Slack allowed on a re-post arriving later than its window says it should.
         private const val SNOOZE_GRACE_MS = 3_000L
 
-        // Upper bound on [snoozedUntil]. Far above the handful that can be in flight within one
-        // snooze window; purely a guard against runaway growth.
-        private const val MAX_TRACKED_SNOOZES = 64
+        // Upper bound on [held], [returning] and [pendingCancel]. Far above the handful that can be
+        // in flight at once; purely a guard against runaway growth.
+        private const val MAX_TRACKED_KEYS = 64
 
         // The currently connected listener, or null when unbound. Only touched on the main thread
         // (the framework's listener callbacks and the overlay both run there).
@@ -477,27 +534,33 @@ class CutoutNotificationListenerService : NotificationListenerService() {
         }
 
         /**
-         * Cancel the notification with [key] from the system, exactly as swiping it away in the
-         * shade would. A no-op if the listener isn't connected (nothing we can do without it).
+         * The user swiped the pill mirroring [key] away, so the notification it stands for is thrown
+         * away too — it never reaches the notification panel. Only when the user asked for
+         * notifications to be dismissed automatically: with that setting off the pill is a mirror and
+         * nothing more, and swiping it leaves the real notification exactly where it is. A no-op if
+         * the listener isn't connected (nothing we can do without it).
          */
         fun dismiss(key: String) {
-            val service = instance ?: return
-            service.snoozedUntil.remove(key)
-            runCatching { service.cancelNotification(key) }
-                .onFailure { Log.w(TAG, "Failed to cancel notification $key", it) }
+            instance?.discard(key, onlyIfHeld = false)
         }
 
         /**
          * The user acted on the pill mirroring [key] — tapped it, fired an action, sent a reply — so
-         * a notification we had merely snoozed has served its purpose and must not resurface. Only
-         * touches keys we snoozed ourselves: one the app still owns is the app's to clear, exactly as
+         * a notification we were holding back has served its purpose and must not resurface. Only
+         * touches keys we hold ourselves: one the app still owns is the app's to clear, exactly as
          * before the island got involved.
          */
         fun settle(key: String) {
-            val service = instance ?: return
-            if (service.snoozedUntil.remove(key) == null) return
-            runCatching { service.cancelNotification(key) }
-                .onFailure { Log.w(TAG, "Failed to cancel snoozed notification $key", it) }
+            instance?.discard(key, onlyIfHeld = true)
+        }
+
+        /**
+         * The pill mirroring [key] went away without the user acting on it — it timed out, or another
+         * event took the island over. A notification held back for it is handed to the notification
+         * panel now, landing as the pill fades. A no-op for a notification we never held.
+         */
+        fun release(key: String) {
+            instance?.releaseHeld(key)
         }
     }
 }

--- a/app/src/main/java/com/ekoehler/expressivecutout/service/NotificationAlerter.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/service/NotificationAlerter.kt
@@ -1,0 +1,139 @@
+package com.ekoehler.expressivecutout.service
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioManager
+import android.media.Ringtone
+import android.media.RingtoneManager
+import android.net.Uri
+import android.os.Build
+import android.os.VibrationAttributes
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import android.util.Log
+
+/**
+ * Plays the ring and the buzz a notification would have made, for the island to use when it takes
+ * one over.
+ *
+ * Holding a notification back from the shade cancels it, and the framework stops whatever sound or
+ * vibration is playing for a notification it cancels — so an alert that began the instant the
+ * notification posted is cut off a few milliseconds later, well before it registers as anything.
+ * This puts it back as the pill appears, drawn from the notification's own channel so an app still
+ * sounds like itself.
+ */
+class NotificationAlerter(private val context: Context) {
+
+    private val audioManager by lazy { context.getSystemService(AudioManager::class.java) }
+
+    private val vibrator by lazy {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            context.getSystemService(VibratorManager::class.java)?.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            context.getSystemService(Vibrator::class.java)
+        }
+    }
+
+    // The sound currently playing, so a notification landing on the heels of another replaces its
+    // ring rather than layering over it — as the framework does with its own.
+    private var playing: Ringtone? = null
+
+    /**
+     * Sound and buzz for a notification on [channel], following the ringer switch the way the shade
+     * would: silent stays silent, vibrate buzzes without a ring, and only a phone free to make noise
+     * makes any. A channel too quiet to have alerted at all ([importance] below
+     * [NotificationManager.IMPORTANCE_DEFAULT], or asking for neither a sound nor a vibration) is
+     * left alone — the island is standing in for the alert, not inventing one.
+     *
+     * Blocking: opens the ringtone. Call it off the main thread.
+     */
+    fun alert(channel: NotificationChannel?, importance: Int) {
+        if (importance < NotificationManager.IMPORTANCE_DEFAULT) return
+        val ringerMode = audioManager?.ringerMode ?: return
+        if (ringerMode == AudioManager.RINGER_MODE_SILENT) return
+
+        // A null channel means the framework told us nothing about how this one should sound, so it
+        // gets the phone's default notification treatment rather than being dropped.
+        val wantsSound = channel == null || channel.sound != null
+        val wantsBuzz = channel == null || channel.shouldVibrate()
+        if (!wantsSound && !wantsBuzz) return
+
+        // On vibrate, a notification that would have rung buzzes instead, whatever its channel asked
+        // for — that is the whole point of the switch.
+        if (ringerMode == AudioManager.RINGER_MODE_VIBRATE) {
+            buzz(channel)
+            return
+        }
+        if (wantsSound) {
+            play(
+                channel?.sound ?: RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
+                channel?.audioAttributes,
+            )
+        }
+        if (wantsBuzz) buzz(channel)
+    }
+
+    /** Stop a ring still playing, so nothing outlives the island that started it. */
+    @Synchronized
+    fun stop() {
+        runCatching { playing?.takeIf { it.isPlaying }?.stop() }
+            .onFailure { Log.w(TAG, "Failed to stop notification sound", it) }
+        playing = null
+    }
+
+    @Synchronized
+    private fun play(uri: Uri?, attributes: AudioAttributes?) {
+        val sound = uri ?: return
+        stop()
+        runCatching {
+            val ringtone = RingtoneManager.getRingtone(context, sound) ?: return
+            ringtone.audioAttributes = attributes ?: NOTIFICATION_ATTRIBUTES
+            ringtone.play()
+            playing = ringtone
+        }.onFailure { Log.w(TAG, "Failed to play notification sound", it) }
+    }
+
+    /**
+     * Buzz with the channel's own pattern where it has one. Most channels don't — they take the
+     * phone's default vibration, which isn't ours to read — so those get a crisp double tap, which is
+     * what a notification feels like on modern hardware.
+     */
+    private fun buzz(channel: NotificationChannel?) {
+        val vibrator = vibrator?.takeIf { it.hasVibrator() } ?: return
+        val pattern = channel?.vibrationPattern
+        val effect = if (pattern != null && pattern.isNotEmpty()) {
+            VibrationEffect.createWaveform(pattern, NO_REPEAT)
+        } else {
+            VibrationEffect.createPredefined(VibrationEffect.EFFECT_DOUBLE_CLICK)
+        }
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                vibrator.vibrate(
+                    effect,
+                    VibrationAttributes.createForUsage(VibrationAttributes.USAGE_NOTIFICATION),
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                vibrator.vibrate(effect, NOTIFICATION_ATTRIBUTES)
+            }
+        }.onFailure { Log.w(TAG, "Failed to vibrate", it) }
+    }
+
+    private companion object {
+        const val TAG = "NotificationAlerter"
+
+        // Play the waveform once through rather than looping it.
+        const val NO_REPEAT = -1
+
+        // What the framework would have used for a notification, so the ring lands on the
+        // notification volume and ducks against media the same way.
+        val NOTIFICATION_ATTRIBUTES: AudioAttributes = AudioAttributes.Builder()
+            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+            .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+            .build()
+    }
+}

--- a/app/src/main/java/com/ekoehler/expressivecutout/service/NotificationAlerter.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/service/NotificationAlerter.kt
@@ -99,8 +99,13 @@ class NotificationAlerter(private val context: Context) {
 
     /**
      * Buzz with the channel's own pattern where it has one. Most channels don't — they take the
-     * phone's default vibration, which isn't ours to read — so those get a crisp double tap, which is
-     * what a notification feels like on modern hardware.
+     * phone's default vibration, which isn't ours to read — so those get [DEFAULT_PATTERN], the same
+     * two firm pulses the platform buzzes for a notification.
+     *
+     * Deliberately a waveform rather than one of the predefined effects: those are haptic-feedback
+     * primitives, sized for a UI touch and pinned to the light amplitude that goes with one, so a
+     * notification built from them feels like a button press instead of something worth looking at.
+     * A waveform is the only form that carries amplitudes, which is what makes it land as a real buzz.
      */
     private fun buzz(channel: NotificationChannel?) {
         val vibrator = vibrator?.takeIf { it.hasVibrator() } ?: return
@@ -108,7 +113,7 @@ class NotificationAlerter(private val context: Context) {
         val effect = if (pattern != null && pattern.isNotEmpty()) {
             VibrationEffect.createWaveform(pattern, NO_REPEAT)
         } else {
-            VibrationEffect.createPredefined(VibrationEffect.EFFECT_DOUBLE_CLICK)
+            VibrationEffect.createWaveform(DEFAULT_PATTERN, DEFAULT_AMPLITUDES, NO_REPEAT)
         }
         runCatching {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -128,6 +133,15 @@ class NotificationAlerter(private val context: Context) {
 
         // Play the waveform once through rather than looping it.
         const val NO_REPEAT = -1
+
+        // What a notification buzzes like when its channel names no pattern of its own: wait none,
+        // pulse, pause, pulse. Mirrors the platform's own default notification vibration.
+        val DEFAULT_PATTERN = longArrayOf(0, 250, 250, 250)
+
+        // Full strength for each pulse in [DEFAULT_PATTERN], zero for the gaps. Amplitudes are given
+        // explicitly rather than left to DEFAULT_AMPLITUDE so the buzz is as strong as the hardware
+        // allows, which is the whole point of standing in for an alert the user would otherwise miss.
+        val DEFAULT_AMPLITUDES = intArrayOf(0, 255, 0, 255)
 
         // What the framework would have used for a notification, so the ring lands on the
         // notification volume and ducks against media the same way.

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
@@ -704,4 +704,8 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     fun setMusicShowProgress(enabled: Boolean) = viewModelScope.launch {
         musicTilePreferences.setShowProgress(enabled)
     }
+
+    fun setDismissNotifications(enabled: Boolean) = viewModelScope.launch {
+        behaviourPreferences.setDismissNotifications(enabled)
+    }
 }

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
@@ -6,8 +6,6 @@ import android.net.Uri
 import android.os.Environment
 import android.provider.MediaStore
 import android.util.Log
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Path
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.ekoehler.expressivecutout.core.DynamicTile
@@ -59,10 +57,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.io.File
-import java.io.FileWriter
 import java.io.IOException
-import kotlin.io.encoding.Base64
 
 /**
  * Holds UI-facing state for the icon customisation screen and mediates writes to
@@ -707,5 +702,9 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
 
     fun setDismissNotifications(enabled: Boolean) = viewModelScope.launch {
         behaviourPreferences.setDismissNotifications(enabled)
+    }
+
+    fun setDisplayWhileDnd(enabled: Boolean) = viewModelScope.launch {
+        behaviourPreferences.setDisplayWhileDnd(enabled)
     }
 }

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/PermissionsTab.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/PermissionsTab.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.rounded.Downloading
 import androidx.compose.material.icons.rounded.Layers
 import androidx.compose.material.icons.rounded.Notifications
 import androidx.compose.material.icons.rounded.NotificationsActive
+import androidx.compose.material.icons.rounded.NotificationsNone
 import androidx.compose.material.icons.rounded.PhoneCallback
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -87,6 +88,8 @@ fun PermissionsTab(contentPadding: PaddingValues) {
 
     fun onTestNotification() = postWithPermission { TestNotifier.send(context) }
 
+    fun onTestPlainNotification() = postWithPermission { TestNotifier.sendPlain(context) }
+
     fun onTestProgressNotification() = postWithPermission { TestNotifier.sendProgress(context) }
 
     Column(
@@ -143,6 +146,13 @@ fun PermissionsTab(contentPadding: PaddingValues) {
                 icon = Icons.Rounded.NotificationsActive,
                 title = stringResource(R.string.action_send_test),
                 onClick = ::onTestNotification,
+            )
+
+            // Send a test notification carrying no action buttons
+            TestCard(
+                icon = Icons.Rounded.NotificationsNone,
+                title = stringResource(R.string.action_send_test_plain),
+                onClick = ::onTestPlainNotification,
             )
 
             // Send a test progress notification

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/BehaviourScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/BehaviourScreen.kt
@@ -208,7 +208,7 @@ internal fun BehaviourScreen(
             }
         }
         SettingsToggleNavCard(
-            shape = groupedShape(isFirst = false, isLast = true),
+            shape = groupedShape(isFirst = false, isLast = false),
             title = stringResource(R.string.behaviour_empty_pill),
             description = stringResource(R.string.behaviour_empty_pill_desc),
             checked = behaviour.showsWhenEmpty,
@@ -217,6 +217,13 @@ internal fun BehaviourScreen(
                 haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                 onOpenShowsWhenEmpty()
             }
+        )
+        SettingsToggleCard(
+            shape = groupedShape(isFirst = false, isLast = true),
+            title = stringResource(R.string.behaviour_dismissNotifs_title),
+            description = stringResource(R.string.behaviour_dismissNotifs_desc),
+            checked = behaviour.dismissNotifications,
+            onCheckedChange = viewModel::setDismissNotifications,
         )
     }
 }

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/BehaviourScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/BehaviourScreen.kt
@@ -219,11 +219,18 @@ internal fun BehaviourScreen(
             }
         )
         SettingsToggleCard(
-            shape = groupedShape(isFirst = false, isLast = true),
+            shape = groupedShape(isFirst = false, isLast = false),
             title = stringResource(R.string.behaviour_dismissNotifs_title),
             description = stringResource(R.string.behaviour_dismissNotifs_desc),
             checked = behaviour.dismissNotifications,
             onCheckedChange = viewModel::setDismissNotifications,
+        )
+        SettingsToggleCard(
+            shape = groupedShape(isFirst = false, isLast = true),
+            title = stringResource(R.string.behaviour_displayWhileDnd_title),
+            description = stringResource(R.string.behaviour_displayWhileDnd_desc),
+            checked = behaviour.displayWhileDnd,
+            onCheckedChange = viewModel::setDisplayWhileDnd
         )
     }
 }

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/SettingsCommon.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/SettingsCommon.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.ekoehler.expressivecutout.R
 import com.ekoehler.expressivecutout.data.AppearanceSettings
+import com.ekoehler.expressivecutout.data.IslandLayout
 import com.ekoehler.expressivecutout.overlay.IslandEvent
 import com.ekoehler.expressivecutout.overlay.IslandPreview
 
@@ -283,6 +284,7 @@ internal fun IslandPreviewPanel(
     event: IslandEvent,
     appearance: AppearanceSettings = AppearanceSettings(),
     showActions: Boolean = true,
+    collapsedHeightDp: Int = IslandLayout.DEFAULT_COLLAPSED.heightDp,
 ) {
     val cutoutOutline = Color.White.copy(alpha = 0.28f)
     // Grow the panel so the island (at its offset) always fits without clipping.
@@ -335,6 +337,7 @@ internal fun IslandPreviewPanel(
                 expanded = expanded,
                 appearance = appearance,
                 showActions = showActions,
+                collapsedHeightDp = collapsedHeightDp,
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -448,4 +448,6 @@
     <string name="music_progress_description">Display a playback progress bar under the controls</string>
     <string name="behaviour_dismissNotifs_title">Automatically dismiss notifications</string>
     <string name="behaviour_dismissNotifs_desc">Keep notifications out of the shade while the island shows them. Ignore one and it comes back a minute later, so nothing is lost</string>
+    <string name="behaviour_displayWhileDnd_title">Display while Do not disturb</string>
+    <string name="behaviour_displayWhileDnd_desc">Display notifications even when do not disturb is enabled</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,8 +55,11 @@
     <string name="status_needed">Tap to enable</string>
     <string name="action_send_test">Send a test notification</string>
     <string name="action_send_test_progress">Send a test progress notification</string>
+    <string name="action_send_test_plain">Send a test notification without buttons</string>
     <string name="test_notification_title">Test notification</string>
     <string name="test_notification_text">Expand the island and try the buttons below.</string>
+    <string name="test_plain_notification_title">Plain test notification</string>
+    <string name="test_plain_notification_text">No action buttons, so the island shows only the header. Check the title clears the camera.</string>
     <string name="test_progress_notification_title">Downloading file</string>
     <string name="test_progress_notification_text">Watch the island track the progress.</string>
     <string name="test_notification_action_reply">Reply</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -447,5 +447,5 @@
     <string name="music_progress_title">Show progress</string>
     <string name="music_progress_description">Display a playback progress bar under the controls</string>
     <string name="behaviour_dismissNotifs_title">Automatically dismiss notifications</string>
-    <string name="behaviour_dismissNotifs_desc">Hide Android standard notification pop-ups</string>
+    <string name="behaviour_dismissNotifs_desc">Keep notifications out of the shade while the island shows them. Ignore one and it comes back a minute later, so nothing is lost</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -446,4 +446,6 @@
     <string name="bgColor_oled_desc">Use pure black for lower consuption on OLED screens</string>
     <string name="music_progress_title">Show progress</string>
     <string name="music_progress_description">Display a playback progress bar under the controls</string>
+    <string name="behaviour_dismissNotifs_title">Automatically dismiss notifications</string>
+    <string name="behaviour_dismissNotifs_desc">Hide Android standard notification pop-ups</string>
 </resources>


### PR DESCRIPTION
In this PR, I added a long-awaited feature that aims to dismiss stock android notifications. As I chose not to use `NotificationAssistant`, I could only dismiss the notification when it's posted, display the cutout, and then if it's ignored, post it again for it to appear in the notification panel.
This is a first version of this feature, I might rework it later but for now it looks like it works. Open for testing. 