### PR TITLE
feat: add setting to ignore silent notifications

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,5 +57,7 @@ dependencies {
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.lottie.compose)
 
+    testImplementation(libs.junit)
+
     debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/app/src/main/java/com/ekoehler/expressivecutout/core/CutoutSignal.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/core/CutoutSignal.kt
@@ -46,7 +46,8 @@ sealed interface CutoutSignal {
          * a valid notification, and the fallback when [largeIcon] is null.
          */
         val smallIcon: Icon? = null,
-        val progressData: ProgressData? = null
+        val progressData: ProgressData? = null,
+        val isSilent: Boolean = false,
     ) : CutoutSignal {
 
         /**

--- a/app/src/main/java/com/ekoehler/expressivecutout/data/BehaviourPreferences.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/data/BehaviourPreferences.kt
@@ -82,6 +82,7 @@ data class BehaviourSettings(
     val expandedCollapseSeconds: Int = DEFAULT_COLLAPSE_SECONDS,
     val expandedDisappearOnShrink: Boolean = DEFAULT_DISAPPEAR_ON_SHRINK,
     val notificationsAutoExpand: Boolean = DEFAULT_NOTIFICATIONS_AUTO_EXPAND,
+    val ignoreSilentNotifications: Boolean = DEFAULT_IGNORE_SILENT_NOTIFICATIONS,
     val showActionButtons: Boolean = DEFAULT_SHOW_ACTION_BUTTONS,
     val toastOnAction: Boolean = DEFAULT_TOAST_ON_ACTION,
     val shrinkOnSwipeUp: Boolean = DEFAULT_SHRINK_ON_SWIPE_UP,
@@ -118,6 +119,7 @@ data class BehaviourSettings(
         const val DEFAULT_COLLAPSE_SECONDS = 5
         const val DEFAULT_DISAPPEAR_ON_SHRINK = false
         const val DEFAULT_NOTIFICATIONS_AUTO_EXPAND = false
+        const val DEFAULT_IGNORE_SILENT_NOTIFICATIONS = false
         const val DEFAULT_SHOW_ACTION_BUTTONS = true
         const val DEFAULT_TOAST_ON_ACTION = true
         const val DEFAULT_SHRINK_ON_SWIPE_UP = true
@@ -179,6 +181,7 @@ class BehaviourPreferences(private val context: Context) : JsonSerializable {
                 .coerceIn(BehaviourSettings.MIN_COLLAPSE_SECONDS, BehaviourSettings.MAX_COLLAPSE_SECONDS),
             expandedDisappearOnShrink = prefs[DISAPPEAR_ON_SHRINK] ?: BehaviourSettings.DEFAULT_DISAPPEAR_ON_SHRINK,
             notificationsAutoExpand = prefs[NOTIF_AUTO_EXPAND] ?: BehaviourSettings.DEFAULT_NOTIFICATIONS_AUTO_EXPAND,
+            ignoreSilentNotifications = prefs[IGNORE_SILENT_NOTIFICATIONS] ?: BehaviourSettings.DEFAULT_IGNORE_SILENT_NOTIFICATIONS,
             showActionButtons = prefs[SHOW_ACTION_BUTTONS] ?: BehaviourSettings.DEFAULT_SHOW_ACTION_BUTTONS,
             toastOnAction = prefs[TOAST_ON_ACTION] ?: BehaviourSettings.DEFAULT_TOAST_ON_ACTION,
             shrinkOnSwipeUp = prefs[SHRINK_ON_SWIPE_UP] ?: BehaviourSettings.DEFAULT_SHRINK_ON_SWIPE_UP,
@@ -223,6 +226,7 @@ class BehaviourPreferences(private val context: Context) : JsonSerializable {
             put("expandedCollapseSeconds", s.expandedCollapseSeconds)
             put("expandedDisappearOnShrink", s.expandedDisappearOnShrink)
             put("notificationsAutoExpand", s.notificationsAutoExpand)
+            put("ignoreSilentNotifications", s.ignoreSilentNotifications)
             put("showActionButtons", s.showActionButtons)
             put("toastOnAction", s.toastOnAction)
             put("shrinkOnSwipeUp", s.shrinkOnSwipeUp)
@@ -272,6 +276,7 @@ class BehaviourPreferences(private val context: Context) : JsonSerializable {
                 .coerceIn(BehaviourSettings.MIN_COLLAPSE_SECONDS, BehaviourSettings.MAX_COLLAPSE_SECONDS)
             if (obj.has("expandedDisappearOnShrink")) it[DISAPPEAR_ON_SHRINK] = obj.getBoolean("expandedDisappearOnShrink")
             if (obj.has("notificationsAutoExpand")) it[NOTIF_AUTO_EXPAND] = obj.getBoolean("notificationsAutoExpand")
+            if (obj.has("ignoreSilentNotifications")) it[IGNORE_SILENT_NOTIFICATIONS] = obj.getBoolean("ignoreSilentNotifications")
             if (obj.has("showActionButtons")) it[SHOW_ACTION_BUTTONS] = obj.getBoolean("showActionButtons")
             if (obj.has("toastOnAction")) it[TOAST_ON_ACTION] = obj.getBoolean("toastOnAction")
             if (obj.has("shrinkOnSwipeUp")) it[SHRINK_ON_SWIPE_UP] = obj.getBoolean("shrinkOnSwipeUp")
@@ -381,6 +386,10 @@ class BehaviourPreferences(private val context: Context) : JsonSerializable {
         it[NOTIF_AUTO_EXPAND] = enabled
     }
 
+    suspend fun setIgnoreSilentNotifications(enabled: Boolean) = context.behaviourDataStore.edit {
+        it[IGNORE_SILENT_NOTIFICATIONS] = enabled
+    }
+
     suspend fun setShowActionButtons(enabled: Boolean) = context.behaviourDataStore.edit {
         it[SHOW_ACTION_BUTTONS] = enabled
     }
@@ -476,6 +485,7 @@ class BehaviourPreferences(private val context: Context) : JsonSerializable {
         val COLLAPSE_SECONDS = intPreferencesKey("expanded_collapse_seconds")
         val DISAPPEAR_ON_SHRINK = booleanPreferencesKey("expanded_disappear_on_shrink")
         val NOTIF_AUTO_EXPAND = booleanPreferencesKey("notifications_auto_expand")
+        val IGNORE_SILENT_NOTIFICATIONS = booleanPreferencesKey("ignore_silent_notifications")
         val SHOW_ACTION_BUTTONS = booleanPreferencesKey("show_action_buttons")
         val TOAST_ON_ACTION = booleanPreferencesKey("toast_on_action")
         val SHRINK_ON_SWIPE_UP = booleanPreferencesKey("shrink_on_swipe_up")

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
@@ -1053,6 +1053,10 @@ class IslandOverlayController(private val context: Context) {
             if (signal is CutoutSignal.Assistant && tileEnabled[DynamicTile.ASSISTANT] == false) return@collect
             // Skip anything posted by an app the user muted on the Apps screen.
             if (signal.sourcePackage() in disabledApps) return@collect
+            // Skip silent notifications when configured to ignore them.
+            if (signal is CutoutSignal.Notification && behaviourState.value.ignoreSilentNotifications && signal.isSilent) {
+                return@collect
+            }
 
             if (signal is CutoutSignal.Assistant && !signal.active) {
                 assistantActive = false

--- a/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/service/CutoutNotificationListenerService.kt
@@ -105,6 +105,10 @@ class CutoutNotificationListenerService : NotificationListenerService() {
     }
 
     override fun onNotificationPosted(sbn: StatusBarNotification?) {
+        onNotificationPosted(sbn, null)
+    }
+
+    override fun onNotificationPosted(sbn: StatusBarNotification?, rankingMap: RankingMap?) {
         val notification = sbn ?: return
 
         // Phone call
@@ -124,6 +128,7 @@ class CutoutNotificationListenerService : NotificationListenerService() {
 
         if (!notification.shouldSurface()) return
 
+        val isSilent = isSilentNotification(notification, rankingMap)
         val extras = notification.notification.extras
         val title = extras?.getCharSequence(Notification.EXTRA_TITLE)?.toString()
         val text = extras?.getCharSequence(Notification.EXTRA_TEXT)?.toString()
@@ -139,8 +144,34 @@ class CutoutNotificationListenerService : NotificationListenerService() {
                 actions = notification.notification.surfaceableActions(),
                 largeIcon = notification.notification.getLargeIcon(),
                 smallIcon = notification.notification.smallIcon,
-                progressData = progress
+                progressData = progress,
+                isSilent = isSilent,
             ),
+        )
+    }
+
+    /**
+     * Determines whether [sbn] represents a silent notification.
+     */
+    fun isSilentNotification(sbn: StatusBarNotification, rankingMap: RankingMap? = null): Boolean {
+        val ranking = Ranking()
+        val found = (rankingMap != null && rankingMap.getRanking(sbn.key, ranking)) ||
+            (currentRanking != null && currentRanking.getRanking(sbn.key, ranking))
+        if (found) {
+            val importance = ranking.importance
+            val isAmbient = ranking.isAmbient
+            val priority = sbn.notification?.priority ?: Notification.PRIORITY_DEFAULT
+            return NotificationClassifier.isSilent(
+                importance = importance,
+                isAmbient = isAmbient,
+                priority = priority,
+            )
+        }
+        val priority = sbn.notification?.priority ?: Notification.PRIORITY_DEFAULT
+        return NotificationClassifier.isSilent(
+            importance = null,
+            isAmbient = false,
+            priority = priority,
         )
     }
 

--- a/app/src/main/java/com/ekoehler/expressivecutout/service/NotificationClassifier.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/service/NotificationClassifier.kt
@@ -1,0 +1,21 @@
+package com.ekoehler.expressivecutout.service
+
+import android.app.Notification
+import android.app.NotificationManager
+
+object NotificationClassifier {
+    /**
+     * Determines if a notification is classified as silent (low/min/none importance or ambient).
+     */
+    fun isSilent(
+        importance: Int?,
+        isAmbient: Boolean = false,
+        priority: Int = Notification.PRIORITY_DEFAULT,
+    ): Boolean {
+        if (isAmbient) return true
+        if (importance != null && importance != NotificationManager.IMPORTANCE_UNSPECIFIED) {
+            return importance < NotificationManager.IMPORTANCE_DEFAULT
+        }
+        return priority < Notification.PRIORITY_DEFAULT
+    }
+}

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
@@ -569,6 +569,10 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         behaviourPreferences.setNotificationsAutoExpand(enabled)
     }
 
+    fun setIgnoreSilentNotifications(enabled: Boolean) = viewModelScope.launch {
+        behaviourPreferences.setIgnoreSilentNotifications(enabled)
+    }
+
     fun setShowActionButtons(enabled: Boolean) = viewModelScope.launch {
         behaviourPreferences.setShowActionButtons(enabled)
     }

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/BehaviourScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/BehaviourScreen.kt
@@ -155,6 +155,13 @@ internal fun BehaviourScreen(
         )
         SettingsToggleCard(
             shape = groupedShape(isFirst = false, isLast = false),
+            title = stringResource(R.string.behaviour_ignore_silent_notif),
+            description = stringResource(R.string.behaviour_ignore_silent_notif_desc),
+            checked = behaviour.ignoreSilentNotifications,
+            onCheckedChange = viewModel::setIgnoreSilentNotifications,
+        )
+        SettingsToggleCard(
+            shape = groupedShape(isFirst = false, isLast = false),
             title = stringResource(R.string.behaviour_action_buttons),
             description = stringResource(R.string.behaviour_action_buttons_desc),
             checked = behaviour.showActionButtons,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -309,6 +309,8 @@
     <string name="behaviour_disappear_desc">When the island shrinks it disappears entirely, instead of returning to the normal cutout.</string>
     <string name="behaviour_notif_auto_expand">Auto-expand notifications</string>
     <string name="behaviour_notif_auto_expand_desc">Show notifications expanded with their title and text, instead of just the app icon.</string>
+    <string name="behaviour_ignore_silent_notif">Ignore silent notifications</string>
+    <string name="behaviour_ignore_silent_notif_desc">Don\'t show a cutout bubble for notifications marked as silent</string>
     <string name="behaviour_action_buttons">Show action buttons</string>
     <string name="behaviour_action_buttons_desc">Show a notification\'s action buttons in the expanded cutout. Adds a little height so they clear the camera.</string>
     <string name="behaviour_shrink_swipe_up">Shrink on swipe up</string>

--- a/app/src/test/java/com/ekoehler/expressivecutout/service/SilentNotificationTest.kt
+++ b/app/src/test/java/com/ekoehler/expressivecutout/service/SilentNotificationTest.kt
@@ -1,0 +1,86 @@
+package com.ekoehler.expressivecutout.service
+
+import android.app.NotificationManager
+import com.ekoehler.expressivecutout.core.CutoutSignal
+import com.ekoehler.expressivecutout.data.BehaviourSettings
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SilentNotificationTest {
+
+    @Test
+    fun testBehaviourSettingsDefaultIgnoreSilentNotifications() {
+        val settings = BehaviourSettings()
+        assertFalse("Default ignoreSilentNotifications should be false", settings.ignoreSilentNotifications)
+    }
+
+    @Test
+    fun testNotificationClassifierIdentifiesSilentNotifications() {
+        // Importance LOW, MIN, NONE should be classified as silent
+        assertTrue(NotificationClassifier.isSilent(importance = NotificationManager.IMPORTANCE_LOW, isAmbient = false))
+        assertTrue(NotificationClassifier.isSilent(importance = NotificationManager.IMPORTANCE_MIN, isAmbient = false))
+        assertTrue(NotificationClassifier.isSilent(importance = NotificationManager.IMPORTANCE_NONE, isAmbient = false))
+        assertTrue(NotificationClassifier.isSilent(importance = NotificationManager.IMPORTANCE_HIGH, isAmbient = true))
+
+        // Importance DEFAULT, HIGH, MAX should NOT be silent
+        assertFalse(NotificationClassifier.isSilent(importance = NotificationManager.IMPORTANCE_DEFAULT, isAmbient = false))
+        assertFalse(NotificationClassifier.isSilent(importance = NotificationManager.IMPORTANCE_HIGH, isAmbient = false))
+        assertFalse(NotificationClassifier.isSilent(importance = NotificationManager.IMPORTANCE_MAX, isAmbient = false))
+    }
+
+    @Test
+    fun testCutoutSignalNotificationCarriesIsSilent() {
+        val silentNotification = CutoutSignal.Notification(
+            packageName = "com.example.chat",
+            title = "Test",
+            text = "Message",
+            isSilent = true,
+        )
+        assertTrue(silentNotification.isSilent)
+
+        val defaultNotification = CutoutSignal.Notification(
+            packageName = "com.example.chat",
+            title = "Test",
+            text = "Message",
+        )
+        assertFalse(defaultNotification.isSilent)
+    }
+
+    @Test
+    fun testNotificationClassifierFallbackPriority() {
+        // When importance is unspecified or null, priority is used as fallback
+        assertTrue(NotificationClassifier.isSilent(importance = NotificationManager.IMPORTANCE_UNSPECIFIED, priority = -1))
+        assertTrue(NotificationClassifier.isSilent(importance = null, priority = -2))
+        assertFalse(NotificationClassifier.isSilent(importance = NotificationManager.IMPORTANCE_UNSPECIFIED, priority = 0))
+        assertFalse(NotificationClassifier.isSilent(importance = null, priority = 1))
+    }
+
+    @Test
+    fun testSilentNotificationFilteringLogic() {
+        val silentSignal = CutoutSignal.Notification(
+            packageName = "com.example.app",
+            title = "Silent Alert",
+            isSilent = true,
+        )
+        val alertingSignal = CutoutSignal.Notification(
+            packageName = "com.example.app",
+            title = "Loud Alert",
+            isSilent = false,
+        )
+
+        fun shouldShowBubble(signal: CutoutSignal.Notification, ignoreSilent: Boolean): Boolean {
+            if (ignoreSilent && signal.isSilent) return false
+            return true
+        }
+
+        // When toggle is OFF: both silent and alerting notifications show bubbles
+        assertTrue(shouldShowBubble(alertingSignal, ignoreSilent = false))
+        assertTrue(shouldShowBubble(silentSignal, ignoreSilent = false))
+
+        // When toggle is ON: alerting shows bubble, silent is suppressed
+        assertTrue(shouldShowBubble(alertingSignal, ignoreSilent = true))
+        assertFalse(shouldShowBubble(silentSignal, ignoreSilent = true))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,10 @@ composeBom = "2024.12.01"
 datastore = "1.1.1"
 savedstate = "1.2.1"
 lottie = "6.6.2"
+junit = "4.13.2"
 
 [libraries]
+junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }


### PR DESCRIPTION
## Summary

Modern Android versions allow notifications and notification channels to be marked as **Silent** or **Default (Alerting)**. Silent notifications appear in the "Silent" section of the notification shade without playing sound, vibrating, or showing heads-up banners.

Previously, Expressive Cutout surfaced cutout bubble animations for **all** clearable notifications regardless of whether they were marked as silent or alerting. This PR introduces an opt-in toggle under **Settings > Behavior** (**"Ignore silent notifications"**) that respects this Android system configuration and suppresses cutout bubbles for silent notifications.

---

## What was done & Why

1. **Notification Silence Detection (`NotificationClassifier` & `CutoutNotificationListenerService`)**
   - Implemented `NotificationClassifier.isSilent(...)` to evaluate notification importance and ambient status (`importance < IMPORTANCE_DEFAULT` or `isAmbient == true`), with backward-compatible priority fallback.
   - Updated `CutoutNotificationListenerService.onNotificationPosted` to receive `RankingMap` from Android's `NotificationListenerService` and tag `CutoutSignal.Notification` with `isSilent: Boolean`.

2. **User Preference & DataStore (`BehaviourSettings`, `BehaviourPreferences`, `AppViewModel`)**
   - Added `ignoreSilentNotifications: Boolean = false` to `BehaviourSettings`.
   - Added DataStore persistence, JSON serialization/deserialization for settings backup/restore, and ViewModel binding.

3. **Overlay Bubble Filtering (`IslandOverlayController`)**
   - When `ignoreSilentNotifications` is enabled, `IslandOverlayController` skips displaying cutout bubble overlays for notifications where `signal.isSilent == true`.

4. **Settings UI (`BehaviourScreen`, `strings.xml`)**
   - Added the "Ignore silent notifications" toggle card under **Settings > Behavior**.

5. **Testability & Unit Tests (`SilentNotificationTest`)**
   - Introduced JUnit test support to the project (`testImplementation(libs.junit)` in `build.gradle.kts` and `libs.versions.toml`).
   - Added `SilentNotificationTest` covering importance classification, ambient status, fallback priorities, signal flags, and filtering logic to guarantee regression prevention.

---

## How it helps the Application & System

- **User Experience**: Users who intentionally silence low-priority notifications (e.g. background syncs, weather updates, ongoing status updates) won't have their screen interrupted by popping cutout bubbles.
- **System Resource Efficiency**: By dropping silent notifications early when configured, the overlay avoids unnecessary compose layout passes and spatial spring animation overhead.
- **Improved Codebase Quality & Testability**: Adds unit testing infrastructure and isolated unit tests to ensure future notification parsing and filtering remains reliable.
