### PR TITLE
feat(appearance): add stroke and background color customization with app-adaptive and event-adaptive support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,4 +63,5 @@ dependencies {
 
     testImplementation(libs.junit)
     debugImplementation(libs.androidx.compose.ui.tooling)
+    testImplementation("junit:junit:4.13.2")
 }

--- a/app/src/main/java/com/ekoehler/expressivecutout/data/AppearancePreferences.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/data/AppearancePreferences.kt
@@ -6,12 +6,14 @@ import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlin.math.roundToInt
 import org.json.JSONObject
 
 /** Backing store for every appearance setting: fills, strokes, icons and action buttons. */
@@ -28,6 +30,7 @@ data class AppearanceSettings(
     val shadowEnabled: Boolean = DEFAULT_SHADOW_ENABLED,
     val strokeEnabled: Boolean = DEFAULT_STROKE_ENABLED,
     val strokeWidthDp: Int = DEFAULT_STROKE_WIDTH_DP,
+    val strokeOpacity: Float = DEFAULT_STROKE_OPACITY,
     val strokeColor: CutoutColor = DEFAULT_STROKE_COLOR,
     val backgroundNormal: CutoutFill = DEFAULT_BACKGROUND_FILL,
     val backgroundExpanded: CutoutFill = DEFAULT_BACKGROUND_FILL,
@@ -47,6 +50,7 @@ data class AppearanceSettings(
         const val DEFAULT_STROKE_WIDTH_DP = 2
         const val MIN_STROKE_WIDTH_DP = 1
         const val MAX_STROKE_WIDTH_DP = 8
+        const val DEFAULT_STROKE_OPACITY = 1f
 
         /** Match the pill's historical look: near-black fill, white stroke. */
         val DEFAULT_BACKGROUND_FILL: CutoutFill = CutoutFill.Solid(ColorSpec.Fixed(0xFF0A0A0A))
@@ -84,6 +88,7 @@ class AppearancePreferences(private val context: Context) : JsonSerializable {
             strokeEnabled = prefs[STROKE_ENABLED] ?: AppearanceSettings.DEFAULT_STROKE_ENABLED,
             strokeWidthDp = (prefs[STROKE_WIDTH] ?: AppearanceSettings.DEFAULT_STROKE_WIDTH_DP)
                 .coerceIn(AppearanceSettings.MIN_STROKE_WIDTH_DP, AppearanceSettings.MAX_STROKE_WIDTH_DP),
+            strokeOpacity = (prefs[STROKE_OPACITY] ?: AppearanceSettings.DEFAULT_STROKE_OPACITY).coerceIn(0f, 1f),
             strokeColor = CutoutColor.deserialize(prefs[STROKE_COLOR]) ?: AppearanceSettings.DEFAULT_STROKE_COLOR,
             // Fall back to the legacy single background colour so existing installs migrate into
             // both states, then to the built-in default.
@@ -115,6 +120,7 @@ class AppearancePreferences(private val context: Context) : JsonSerializable {
             put("shadowEnabled", s.shadowEnabled)
             put("strokeEnabled", s.strokeEnabled)
             put("strokeWidthDp", s.strokeWidthDp)
+            put("strokeOpacity", s.strokeOpacity.toDouble())
             put("strokeColor", s.strokeColor.serialize())
             put("backgroundNormal", s.backgroundNormal.serialize())
             put("backgroundExpanded", s.backgroundExpanded.serialize())
@@ -142,6 +148,7 @@ class AppearancePreferences(private val context: Context) : JsonSerializable {
             if (obj.has("strokeEnabled")) it[STROKE_ENABLED] = obj.getBoolean("strokeEnabled")
             if (obj.has("strokeWidthDp")) it[STROKE_WIDTH] = obj.getInt("strokeWidthDp")
                 .coerceIn(AppearanceSettings.MIN_STROKE_WIDTH_DP, AppearanceSettings.MAX_STROKE_WIDTH_DP)
+            if (obj.has("strokeOpacity")) it[STROKE_OPACITY] = obj.getDouble("strokeOpacity").toFloat().coerceIn(0f, 1f)
             if (obj.has("strokeColor") && !obj.isNull("strokeColor")) {
                 CutoutColor.deserialize(obj.optString("strokeColor"))?.let { c -> it[STROKE_COLOR] = c.serialize() }
             }
@@ -201,6 +208,10 @@ class AppearancePreferences(private val context: Context) : JsonSerializable {
             AppearanceSettings.MIN_STROKE_WIDTH_DP,
             AppearanceSettings.MAX_STROKE_WIDTH_DP,
         )
+    }
+
+    suspend fun setStrokeOpacity(opacity: Float) = context.appearanceDataStore.edit {
+        it[STROKE_OPACITY] = opacity.coerceIn(0f, 1f)
     }
 
     suspend fun setStrokeColor(color: CutoutColor) = context.appearanceDataStore.edit {
@@ -265,6 +276,7 @@ class AppearancePreferences(private val context: Context) : JsonSerializable {
         val SHADOW_ENABLED = booleanPreferencesKey("shadow_enabled")
         val STROKE_ENABLED = booleanPreferencesKey("stroke_enabled")
         val STROKE_WIDTH = intPreferencesKey("stroke_width_dp")
+        val STROKE_OPACITY = floatPreferencesKey("stroke_opacity")
         val STROKE_COLOR = stringPreferencesKey("stroke_color")
         /**
          * Legacy single-colour key, still read to migrate existing installs into the two new keys.

--- a/app/src/main/java/com/ekoehler/expressivecutout/data/AppearancePreferences.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/data/AppearancePreferences.kt
@@ -32,6 +32,7 @@ data class AppearanceSettings(
     val strokeWidthDp: Int = DEFAULT_STROKE_WIDTH_DP,
     val strokeOpacity: Float = DEFAULT_STROKE_OPACITY,
     val strokeColor: CutoutColor = DEFAULT_STROKE_COLOR,
+    val textColor: CutoutColor? = DEFAULT_TEXT_COLOR,
     val backgroundNormal: CutoutFill = DEFAULT_BACKGROUND_FILL,
     val backgroundExpanded: CutoutFill = DEFAULT_BACKGROUND_FILL,
     val sendButtonColor: CutoutColor? = DEFAULT_SEND_BUTTON_COLOR,
@@ -55,6 +56,8 @@ data class AppearanceSettings(
         /** Match the pill's historical look: near-black fill, white stroke. */
         val DEFAULT_BACKGROUND_FILL: CutoutFill = CutoutFill.Solid(ColorSpec.Fixed(0xFF0A0A0A))
         val DEFAULT_STROKE_COLOR: CutoutColor = CutoutColor.Solid(0xFFFFFFFF)
+        /** null means automatic high-contrast text color based on background luminance. */
+        val DEFAULT_TEXT_COLOR: CutoutColor? = null
 
         /**
          * null keeps the historical reply-button look: the send button matches the notification's
@@ -90,6 +93,7 @@ class AppearancePreferences(private val context: Context) : JsonSerializable {
                 .coerceIn(AppearanceSettings.MIN_STROKE_WIDTH_DP, AppearanceSettings.MAX_STROKE_WIDTH_DP),
             strokeOpacity = (prefs[STROKE_OPACITY] ?: AppearanceSettings.DEFAULT_STROKE_OPACITY).coerceIn(0f, 1f),
             strokeColor = CutoutColor.deserialize(prefs[STROKE_COLOR]) ?: AppearanceSettings.DEFAULT_STROKE_COLOR,
+            textColor = CutoutColor.deserialize(prefs[TEXT_COLOR]),
             // Fall back to the legacy single background colour so existing installs migrate into
             // both states, then to the built-in default.
             backgroundNormal = CutoutFill.deserialize(prefs[BACKGROUND_NORMAL] ?: prefs[BACKGROUND_COLOR])
@@ -122,6 +126,7 @@ class AppearancePreferences(private val context: Context) : JsonSerializable {
             put("strokeWidthDp", s.strokeWidthDp)
             put("strokeOpacity", s.strokeOpacity.toDouble())
             put("strokeColor", s.strokeColor.serialize())
+            put("textColor", s.textColor?.serialize() ?: JSONObject.NULL)
             put("backgroundNormal", s.backgroundNormal.serialize())
             put("backgroundExpanded", s.backgroundExpanded.serialize())
             put("sendButtonColor", s.sendButtonColor?.serialize() ?: JSONObject.NULL)
@@ -152,6 +157,7 @@ class AppearancePreferences(private val context: Context) : JsonSerializable {
             if (obj.has("strokeColor") && !obj.isNull("strokeColor")) {
                 CutoutColor.deserialize(obj.optString("strokeColor"))?.let { c -> it[STROKE_COLOR] = c.serialize() }
             }
+            it.applyNullableColor(obj, "textColor", TEXT_COLOR)
             if (obj.has("backgroundNormal") && !obj.isNull("backgroundNormal")) {
                 CutoutFill.deserialize(obj.optString("backgroundNormal"))?.let { f -> it[BACKGROUND_NORMAL] = f.serialize() }
             }
@@ -218,6 +224,11 @@ class AppearancePreferences(private val context: Context) : JsonSerializable {
         it[STROKE_COLOR] = color.serialize()
     }
 
+    /** A null [color] clears the override, restoring automatic contrast-based text color. */
+    suspend fun setTextColor(color: CutoutColor?) = context.appearanceDataStore.edit {
+        if (color == null) it.remove(TEXT_COLOR) else it[TEXT_COLOR] = color.serialize()
+    }
+
     suspend fun setBackgroundNormal(fill: CutoutFill) = context.appearanceDataStore.edit {
         it[BACKGROUND_NORMAL] = fill.serialize()
     }
@@ -278,6 +289,7 @@ class AppearancePreferences(private val context: Context) : JsonSerializable {
         val STROKE_WIDTH = intPreferencesKey("stroke_width_dp")
         val STROKE_OPACITY = floatPreferencesKey("stroke_opacity")
         val STROKE_COLOR = stringPreferencesKey("stroke_color")
+        val TEXT_COLOR = stringPreferencesKey("text_color")
         /**
          * Legacy single-colour key, still read to migrate existing installs into the two new keys.
          */

--- a/app/src/main/java/com/ekoehler/expressivecutout/data/CutoutColor.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/data/CutoutColor.kt
@@ -21,9 +21,6 @@ enum class AppColorFallback {
     }
 }
 
-/** Direction a [CutoutFill.AppFade] color fade runs horizontally across the island. */
-enum class FadeDirection { LEFT_TO_RIGHT, RIGHT_TO_LEFT }
-
 /** Direction a [CutoutFill.Gradient] runs across the island. */
 enum class GradientDirection { VERTICAL, DIAGONAL, HORIZONTAL }
 
@@ -163,7 +160,7 @@ sealed interface ColorSpec {
 
 /**
  * The fill painted behind the island. Richer than [CutoutColor] (it also allows a two-colour
- * [Gradient] and an [AppFade]) and used only for the background, which has an independent value for the collapsed
+ * [Gradient]) and used only for the background, which has an independent value for the collapsed
  * ([AppearanceSettings.backgroundNormal]) and expanded ([AppearanceSettings.backgroundExpanded])
  * states. Serialized to a single string so it fits one preference key.
  *
@@ -181,24 +178,14 @@ sealed interface CutoutFill {
         val direction: GradientDirection,
         val opacity: Float = 1f,
     ) : CutoutFill
-    /** A subtle fade from the active app's branding color into [baseColor] across the island. */
-    data class AppFade(
-        val appColorSpec: ColorSpec.AppIcon = ColorSpec.AppIcon(),
-        val baseColor: ColorSpec = ColorSpec.Fixed(0xFF000000L),
-        val direction: FadeDirection = FadeDirection.LEFT_TO_RIGHT,
-        val solidPercent: Int = 30,
-        val fadeDistance: Int = 20,
-        val opacity: Float = 1f,
-    ) : CutoutFill
 
     /**
-     * Encodes to the stop-delimited `gradient|start|end|DIRECTION|opacity`, `app_fade|...`, or delegates to the single
+     * Encodes to the stop-delimited `gradient|start|end|DIRECTION|opacity` or delegates to the single
      * colour for [Solid]. Read back by [deserialize].
      */
     fun serialize(): String = when (this) {
         is Solid -> color.serialize()
         is Gradient -> listOf(GRADIENT, start.serialize(), end.serialize(), direction.name, opacity.toString()).joinToString("|")
-        is AppFade -> listOf(APP_FADE, appColorSpec.serialize(), baseColor.serialize(), direction.name, solidPercent.toString(), fadeDistance.toString(), opacity.toString()).joinToString("|")
     }
 
     companion object {
@@ -217,15 +204,12 @@ sealed interface CutoutFill {
                 if (start != null && end != null) Gradient(start, end, direction, opacity) else null
             }
             value.startsWith("$APP_FADE|") -> {
+                // Migrate legacy app_fade serialization into a horizontal gradient
                 val parts = value.split('|')
                 val appColor = (ColorSpec.deserialize(parts.getOrNull(1)) as? ColorSpec.AppIcon) ?: ColorSpec.AppIcon()
                 val baseColor = ColorSpec.deserialize(parts.getOrNull(2)) ?: ColorSpec.Fixed(0xFF000000L)
-                val direction = runCatching { FadeDirection.valueOf(parts[3]) }
-                    .getOrDefault(FadeDirection.LEFT_TO_RIGHT)
-                val solidPercent = parts.getOrNull(4)?.toIntOrNull()?.coerceIn(0, 100) ?: 30
-                val fadeDistance = parts.getOrNull(5)?.toIntOrNull()?.coerceIn(0, 100) ?: 20
                 val opacity = parts.getOrNull(6)?.toFloatOrNull()?.coerceIn(0f, 1f) ?: 1f
-                AppFade(appColor, baseColor, direction, solidPercent, fadeDistance, opacity)
+                Gradient(start = appColor, end = baseColor, direction = GradientDirection.HORIZONTAL, opacity = opacity)
             }
             // Anything else is a single colour (incl. the legacy "dynamic" / bare-ARGB encodings).
             else -> ColorSpec.deserialize(value)?.let(::Solid)

--- a/app/src/main/java/com/ekoehler/expressivecutout/data/CutoutColor.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/data/CutoutColor.kt
@@ -3,10 +3,33 @@ package com.ekoehler.expressivecutout.data
 import androidx.compose.runtime.Immutable
 import kotlin.math.roundToInt
 
+/** Which Material You colour-scheme role a [CutoutColor.Dynamic] / [ColorSpec.Dynamic] follows. */
+enum class DynamicRole { PRIMARY, SECONDARY, TERTIARY }
+
+/** Fallback color strategy when AppIcon color is chosen but no app notification is active. */
+enum class AppColorFallback {
+    /** Material You primary dynamic accent. */
+    DYNAMIC_THEME,
+    /** OLED Pure Black (#000000). */
+    OLED_BLACK,
+    /** Adaptive (Media Art for music, Material You for system events). */
+    ADAPTIVE;
+
+    companion object {
+        fun deserialize(value: String?): AppColorFallback =
+            value?.let { runCatching { valueOf(it) }.getOrNull() } ?: ADAPTIVE
+    }
+}
+
+/** Direction a [CutoutFill.AppFade] color fade runs horizontally across the island. */
+enum class FadeDirection { LEFT_TO_RIGHT, RIGHT_TO_LEFT }
+
+/** Direction a [CutoutFill.Gradient] runs across the island. */
+enum class GradientDirection { VERTICAL, DIAGONAL, HORIZONTAL }
+
 /**
- * A user-selectable colour for the island. Either a fixed ARGB value or [Dynamic], which resolves
- * to one of the system's Material You scheme roles at render time (so it follows the wallpaper on
- * Android 12+). Stored as a short string so it can live in a single preference key.
+ * A user-selectable colour for the island. Either a fixed ARGB value, [Dynamic] (Material You),
+ * or [AppIcon] which extracts the primary color of the active app's default launcher icon.
  */
 @Immutable
 sealed interface CutoutColor {
@@ -23,16 +46,23 @@ sealed interface CutoutColor {
     data class Solid(val argb: Long) : CutoutColor
 
     /**
-     * Encodes to the single string held in preferences: `dynamic:ROLE`, or the bare ARGB number.
+     * A colour dynamically extracted from the active app's launcher icon, with a configurable [fallback].
+     */
+    data class AppIcon(val fallback: AppColorFallback = AppColorFallback.ADAPTIVE) : CutoutColor
+
+    /**
+     * Encodes to the single string held in preferences: `dynamic:ROLE`, `app_icon:FALLBACK`, or the bare ARGB number.
      * Read back by [deserialize].
      */
     fun serialize(): String = when (this) {
         is Dynamic -> "$DYNAMIC:${role.name}"
         is Solid -> argb.toString()
+        is AppIcon -> "$APP_ICON:${fallback.name}"
     }
 
     companion object {
         private const val DYNAMIC = "dynamic"
+        private const val APP_ICON = "app_icon"
 
         fun deserialize(value: String?): CutoutColor? = when {
             value == null -> null
@@ -43,21 +73,20 @@ sealed interface CutoutColor {
                     .getOrDefault(DynamicRole.PRIMARY)
                 Dynamic(role)
             }
+            value == APP_ICON -> AppIcon(AppColorFallback.ADAPTIVE)
+            value.startsWith("$APP_ICON:") -> {
+                val fallback = AppColorFallback.deserialize(value.substringAfter(':'))
+                AppIcon(fallback)
+            }
             else -> value.toLongOrNull()?.let(::Solid)
         }
     }
 }
 
-/** Which Material You colour-scheme role a [CutoutColor.Dynamic] / [ColorSpec.Dynamic] follows. */
-enum class DynamicRole { PRIMARY, SECONDARY, TERTIARY }
-
-/** Direction a [CutoutFill.Gradient] runs across the island. */
-enum class GradientDirection { VERTICAL, DIAGONAL, HORIZONTAL }
-
 /**
  * A single resolvable colour used by a [CutoutFill] (as a solid fill or a gradient stop): either a
- * [Fixed] ARGB value or a Material You [Dynamic] role resolved at render time. Both carry an
- * opacity — [Fixed] in its ARGB alpha byte, [Dynamic] in [Dynamic.alpha] — so any colour can be
+ * [Fixed] ARGB value, a Material You [Dynamic] role resolved at render time, or an [AppIcon] extracted color.
+ * Both carry an opacity — [Fixed] in its ARGB alpha byte, [Dynamic]/[AppIcon] in [alpha] — so any colour can be
  * made translucent. Serialized without the `:` used by [Fixed] so gradients can delimit on `|`.
  */
 @Immutable
@@ -71,33 +100,43 @@ sealed interface ColorSpec {
      */
     data class Dynamic(val role: DynamicRole, val alpha: Float = 1f) : ColorSpec
 
+    /** An app launcher icon extracted color, with [alpha] holding the opacity separately. */
+    data class AppIcon(val fallback: AppColorFallback = AppColorFallback.ADAPTIVE, val alpha: Float = 1f) : ColorSpec
+
     /** 0f..1f opacity of this colour. */
     val opacity: Float
         get() = when (this) {
             is Fixed -> ((argb ushr 24) and 0xFF) / 255f
             is Dynamic -> alpha
+            is AppIcon -> alpha
         }
 
     /** A copy of this colour at the given [opacity] (0f..1f). */
     fun withOpacity(opacity: Float): ColorSpec {
-        val a = (opacity.coerceIn(0f, 1f) * 255f).roundToInt().toLong()
+        val a = opacity.coerceIn(0f, 1f)
         return when (this) {
-            is Fixed -> Fixed((argb and 0x00FFFFFFL) or (a shl 24))
-            is Dynamic -> copy(alpha = opacity.coerceIn(0f, 1f))
+            is Fixed -> {
+                val alphaByte = (a * 255f).roundToInt().toLong()
+                Fixed((argb and 0x00FFFFFFL) or (alphaByte shl 24))
+            }
+            is Dynamic -> copy(alpha = a)
+            is AppIcon -> copy(alpha = a)
         }
     }
 
     /**
-     * Encodes to `dynamic:ROLE:ALPHA` or the bare ARGB number. Never contains a `|`, which is what
+     * Encodes to `dynamic:ROLE:ALPHA`, `app_icon:FALLBACK:ALPHA`, or the bare ARGB number. Never contains a `|`, which is what
      * lets [CutoutFill.Gradient] delimit its stops on one.
      */
     fun serialize(): String = when (this) {
         is Fixed -> argb.toString()
         is Dynamic -> "$DYNAMIC:${role.name}:$alpha"
+        is AppIcon -> "$APP_ICON:${fallback.name}:$alpha"
     }
 
     companion object {
         private const val DYNAMIC = "dynamic"
+        private const val APP_ICON = "app_icon"
 
         fun deserialize(value: String?): ColorSpec? = when {
             value == null -> null
@@ -109,6 +148,13 @@ sealed interface ColorSpec {
                 val alpha = parts.getOrNull(2)?.toFloatOrNull() ?: 1f
                 Dynamic(role, alpha.coerceIn(0f, 1f))
             }
+            value == APP_ICON -> AppIcon(AppColorFallback.ADAPTIVE)
+            value.startsWith("$APP_ICON:") -> {
+                val parts = value.split(':')
+                val fallback = AppColorFallback.deserialize(parts.getOrNull(1))
+                val alpha = parts.getOrNull(2)?.toFloatOrNull() ?: 1f
+                AppIcon(fallback, alpha.coerceIn(0f, 1f))
+            }
             // A bare ARGB number.
             else -> value.toLongOrNull()?.let(::Fixed)
         }
@@ -117,7 +163,7 @@ sealed interface ColorSpec {
 
 /**
  * The fill painted behind the island. Richer than [CutoutColor] (it also allows a two-colour
- * [Gradient]) and used only for the background, which has an independent value for the collapsed
+ * [Gradient] and an [AppFade]) and used only for the background, which has an independent value for the collapsed
  * ([AppearanceSettings.backgroundNormal]) and expanded ([AppearanceSettings.backgroundExpanded])
  * states. Serialized to a single string so it fits one preference key.
  *
@@ -133,19 +179,31 @@ sealed interface CutoutFill {
         val start: ColorSpec,
         val end: ColorSpec,
         val direction: GradientDirection,
+        val opacity: Float = 1f,
+    ) : CutoutFill
+    /** A subtle fade from the active app's branding color into [baseColor] across the island. */
+    data class AppFade(
+        val appColorSpec: ColorSpec.AppIcon = ColorSpec.AppIcon(),
+        val baseColor: ColorSpec = ColorSpec.Fixed(0xFF000000L),
+        val direction: FadeDirection = FadeDirection.LEFT_TO_RIGHT,
+        val solidPercent: Int = 30,
+        val fadeDistance: Int = 20,
+        val opacity: Float = 1f,
     ) : CutoutFill
 
     /**
-     * Encodes to the stop-delimited `gradient|start|end|DIRECTION`, or delegates to the single
+     * Encodes to the stop-delimited `gradient|start|end|DIRECTION|opacity`, `app_fade|...`, or delegates to the single
      * colour for [Solid]. Read back by [deserialize].
      */
     fun serialize(): String = when (this) {
         is Solid -> color.serialize()
-        is Gradient -> listOf(GRADIENT, start.serialize(), end.serialize(), direction.name).joinToString("|")
+        is Gradient -> listOf(GRADIENT, start.serialize(), end.serialize(), direction.name, opacity.toString()).joinToString("|")
+        is AppFade -> listOf(APP_FADE, appColorSpec.serialize(), baseColor.serialize(), direction.name, solidPercent.toString(), fadeDistance.toString(), opacity.toString()).joinToString("|")
     }
 
     companion object {
         private const val GRADIENT = "gradient"
+        private const val APP_FADE = "app_fade"
 
         fun deserialize(value: String?): CutoutFill? = when {
             value == null -> null
@@ -155,7 +213,19 @@ sealed interface CutoutFill {
                 val end = ColorSpec.deserialize(parts.getOrNull(2))
                 val direction = runCatching { GradientDirection.valueOf(parts[3]) }
                     .getOrDefault(GradientDirection.VERTICAL)
-                if (start != null && end != null) Gradient(start, end, direction) else null
+                val opacity = parts.getOrNull(4)?.toFloatOrNull()?.coerceIn(0f, 1f) ?: 1f
+                if (start != null && end != null) Gradient(start, end, direction, opacity) else null
+            }
+            value.startsWith("$APP_FADE|") -> {
+                val parts = value.split('|')
+                val appColor = (ColorSpec.deserialize(parts.getOrNull(1)) as? ColorSpec.AppIcon) ?: ColorSpec.AppIcon()
+                val baseColor = ColorSpec.deserialize(parts.getOrNull(2)) ?: ColorSpec.Fixed(0xFF000000L)
+                val direction = runCatching { FadeDirection.valueOf(parts[3]) }
+                    .getOrDefault(FadeDirection.LEFT_TO_RIGHT)
+                val solidPercent = parts.getOrNull(4)?.toIntOrNull()?.coerceIn(0, 100) ?: 30
+                val fadeDistance = parts.getOrNull(5)?.toIntOrNull()?.coerceIn(0, 100) ?: 20
+                val opacity = parts.getOrNull(6)?.toFloatOrNull()?.coerceIn(0f, 1f) ?: 1f
+                AppFade(appColor, baseColor, direction, solidPercent, fadeDistance, opacity)
             }
             // Anything else is a single colour (incl. the legacy "dynamic" / bare-ARGB encodings).
             else -> ColorSpec.deserialize(value)?.let(::Solid)

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/AppIconColorExtractor.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/AppIconColorExtractor.kt
@@ -1,0 +1,136 @@
+package com.ekoehler.expressivecutout.overlay
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color as AndroidColor
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.os.Build
+import android.util.LruCache
+import androidx.compose.ui.graphics.Color
+import androidx.core.graphics.createBitmap
+
+/**
+ * Extracts the primary branding color from an application's default launcher icon.
+ * Results are cached by package name to avoid redundant icon decoding and palette analysis.
+ */
+object AppIconColorExtractor {
+    private val colorCache = LruCache<String, Int>(64)
+
+    /**
+     * Retrieves the primary color for [packageName], or null if it cannot be resolved.
+     */
+    fun extractAppColor(context: Context, packageName: String): Color? {
+        val cached = colorCache.get(packageName)
+        if (cached != null) {
+            return Color(cached)
+        }
+
+        val drawable = getPlainAppIcon(context, packageName) ?: return null
+        val bitmap = drawableToBitmap(drawable, 48, 48)
+        val extractedInt = extractDominantColor(bitmap) ?: return null
+        colorCache.put(packageName, extractedInt)
+        return Color(extractedInt)
+    }
+
+    /**
+     * Fetches the plain default launcher icon for an application, avoiding themed/dynamic icon tinting.
+     */
+    private fun getPlainAppIcon(context: Context, packageName: String): Drawable? = runCatching {
+        val pm = context.packageManager
+        val launchIntent = pm.getLaunchIntentForPackage(packageName)
+        if (launchIntent != null) {
+            val resolveInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                pm.resolveActivity(launchIntent, PackageManager.ResolveInfoFlags.of(0))
+            } else {
+                pm.resolveActivity(launchIntent, 0)
+            }
+            val icon = resolveInfo?.activityInfo?.loadIcon(pm)
+            if (icon != null) return@runCatching icon
+        }
+        pm.getApplicationIcon(packageName)
+    }.getOrNull()
+
+    private fun drawableToBitmap(drawable: Drawable, width: Int, height: Int): Bitmap {
+        if (drawable is BitmapDrawable && drawable.bitmap != null) {
+            val src = drawable.bitmap
+            if (src.width == width && src.height == height) return src
+            return Bitmap.createScaledBitmap(src, width, height, true)
+        }
+        val bitmap = createBitmap(width, height)
+        val canvas = Canvas(bitmap)
+        drawable.setBounds(0, 0, width, height)
+        drawable.draw(canvas)
+        return bitmap
+    }
+
+    /**
+     * Extracts the primary vibrant/dominant branding color from a [Bitmap].
+     * Saturated, vivid colors are scored higher than neutral/dark/white background pixels.
+     */
+    private fun extractDominantColor(bitmap: Bitmap): Int? {
+        val width = bitmap.width
+        val height = bitmap.height
+        val pixels = IntArray(width * height)
+        bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+
+        var bestColor: Int? = null
+        var highestScore = -1f
+
+        // Count color occurrences bucketed by quantized RGB (4-bits per channel -> 4096 bins)
+        val buckets = mutableMapOf<Int, Int>()
+        val representativeColors = mutableMapOf<Int, LongArray>() // [rSum, gSum, bSum]
+
+        val hsv = FloatArray(3)
+        for (pixel in pixels) {
+            val alpha = AndroidColor.alpha(pixel)
+            if (alpha < 100) continue // Skip transparent pixels
+
+            val r = AndroidColor.red(pixel)
+            val g = AndroidColor.green(pixel)
+            val b = AndroidColor.blue(pixel)
+
+            val qr = (r shr 4)
+            val qg = (g shr 4)
+            val qb = (b shr 4)
+            val key = (qr shl 8) or (qg shl 4) or qb
+
+            buckets[key] = (buckets[key] ?: 0) + 1
+            val sums = representativeColors.getOrPut(key) { LongArray(3) }
+            sums[0] += r.toLong()
+            sums[1] += g.toLong()
+            sums[2] += b.toLong()
+        }
+
+        if (buckets.isEmpty()) return null
+
+        for ((key, count) in buckets) {
+            val sums = representativeColors[key] ?: continue
+            val r = (sums[0] / count).toInt().coerceIn(0, 255)
+            val g = (sums[1] / count).toInt().coerceIn(0, 255)
+            val b = (sums[2] / count).toInt().coerceIn(0, 255)
+
+            AndroidColor.RGBToHSV(r, g, b, hsv)
+            val saturation = hsv[1] // 0.0 .. 1.0
+            val value = hsv[2] // 0.0 .. 1.0
+
+            // Score favoring saturated, well-lit colors over dull grays/whites/blacks
+            val saturationWeight = saturation * saturation * 4.0f + 0.1f
+            val brightnessWeight = when {
+                value < 0.15f -> 0.1f // too dark
+                value > 0.95f && saturation < 0.15f -> 0.1f // plain white/near white
+                else -> 1.0f
+            }
+
+            val score = count * saturationWeight * brightnessWeight
+            if (score > highestScore) {
+                highestScore = score
+                bestColor = AndroidColor.rgb(r, g, b)
+            }
+        }
+
+        return bestColor
+    }
+}

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/CutoutColors.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/CutoutColors.kt
@@ -16,7 +16,6 @@ import com.ekoehler.expressivecutout.data.ColorSpec
 import com.ekoehler.expressivecutout.data.CutoutColor
 import com.ekoehler.expressivecutout.data.CutoutFill
 import com.ekoehler.expressivecutout.data.DynamicRole
-import com.ekoehler.expressivecutout.data.FadeDirection
 import com.ekoehler.expressivecutout.data.GradientDirection
 
 /** Fallback accent used for dynamic colours before Android 12 (no Material You). */
@@ -92,8 +91,7 @@ fun ColorSpec.resolveColor(
 
 /**
  * Resolve a [CutoutFill] to the [Brush] painted behind the island. A [CutoutFill.Solid] is a flat
- * [SolidColor]; a [CutoutFill.Gradient] becomes a two-stop gradient in its chosen direction;
- * a [CutoutFill.AppFade] renders a directional fade with solid percentage into the base color.
+ * [SolidColor]; a [CutoutFill.Gradient] becomes a two-stop gradient in its chosen direction.
  */
 @Composable
 fun CutoutFill.resolveBrush(appColor: Color? = null, adaptiveColor: Color? = null): Brush = when (this) {
@@ -107,83 +105,6 @@ fun CutoutFill.resolveBrush(appColor: Color? = null, adaptiveColor: Color? = nul
             GradientDirection.HORIZONTAL -> Brush.horizontalGradient(colors)
             GradientDirection.DIAGONAL -> Brush.linearGradient(colors)
         }
-    }
-    is CutoutFill.AppFade -> {
-        val resolvedApp = appColorSpec.resolve(appColor, adaptiveColor).let { it.copy(alpha = it.alpha * opacity) }
-        val resolvedBase = baseColor.resolve(appColor, adaptiveColor).let { it.copy(alpha = it.alpha * opacity) }
-        val gFrac = (solidPercent / 100f).coerceIn(0f, 1f)
-        val fFrac = (fadeDistance / 100f).coerceIn(0f, 1f)
-
-        val stops = when (direction) {
-            FadeDirection.LEFT_TO_RIGHT -> {
-                val fadeEnd = (gFrac + fFrac).coerceIn(0f, 1f)
-                if (gFrac <= 0f && fFrac <= 0f) {
-                    arrayOf(0.0f to resolvedBase, 1.0f to resolvedBase)
-                } else if (gFrac >= 1f) {
-                    arrayOf(0.0f to resolvedApp, 1.0f to resolvedApp)
-                } else if (fFrac <= 0f) {
-                    // Harsh break at gFrac
-                    arrayOf(
-                        0.0f to resolvedApp,
-                        gFrac to resolvedApp,
-                        gFrac to resolvedBase,
-                        1.0f to resolvedBase,
-                    )
-                } else {
-                    if (gFrac <= 0f) {
-                        if (fadeEnd >= 1f) {
-                            arrayOf(0.0f to resolvedApp, 1.0f to resolvedBase)
-                        } else {
-                            arrayOf(0.0f to resolvedApp, fadeEnd to resolvedBase, 1.0f to resolvedBase)
-                        }
-                    } else if (fadeEnd >= 1f) {
-                        arrayOf(0.0f to resolvedApp, gFrac to resolvedApp, 1.0f to resolvedBase)
-                    } else {
-                        arrayOf(
-                            0.0f to resolvedApp,
-                            gFrac to resolvedApp,
-                            fadeEnd to resolvedBase,
-                            1.0f to resolvedBase,
-                        )
-                    }
-                }
-            }
-            FadeDirection.RIGHT_TO_LEFT -> {
-                val appStart = (1f - gFrac).coerceIn(0f, 1f)
-                val fadeStart = (1f - gFrac - fFrac).coerceIn(0f, 1f)
-                if (gFrac <= 0f && fFrac <= 0f) {
-                    arrayOf(0.0f to resolvedBase, 1.0f to resolvedBase)
-                } else if (gFrac >= 1f) {
-                    arrayOf(0.0f to resolvedApp, 1.0f to resolvedApp)
-                } else if (fFrac <= 0f) {
-                    // Harsh break at appStart
-                    arrayOf(
-                        0.0f to resolvedBase,
-                        appStart to resolvedBase,
-                        appStart to resolvedApp,
-                        1.0f to resolvedApp,
-                    )
-                } else {
-                    if (gFrac <= 0f) {
-                        if (fadeStart <= 0f) {
-                            arrayOf(0.0f to resolvedBase, 1.0f to resolvedApp)
-                        } else {
-                            arrayOf(0.0f to resolvedBase, fadeStart to resolvedBase, 1.0f to resolvedApp)
-                        }
-                    } else if (fadeStart <= 0f) {
-                        arrayOf(0.0f to resolvedBase, appStart to resolvedApp, 1.0f to resolvedApp)
-                    } else {
-                        arrayOf(
-                            0.0f to resolvedBase,
-                            fadeStart to resolvedBase,
-                            appStart to resolvedApp,
-                            1.0f to resolvedApp,
-                        )
-                    }
-                }
-            }
-        }
-        Brush.horizontalGradient(colorStops = stops)
     }
 }
 
@@ -199,23 +120,14 @@ fun CutoutFill.representativeColor(appColor: Color? = null, adaptiveColor: Color
         end.resolve(appColor, adaptiveColor).let { it.copy(alpha = it.alpha * opacity) },
         0.5f,
     )
-    is CutoutFill.AppFade -> lerp(
-        appColorSpec.resolve(appColor, adaptiveColor).let { it.copy(alpha = it.alpha * opacity) },
-        baseColor.resolve(appColor, adaptiveColor).let { it.copy(alpha = it.alpha * opacity) },
-        0.5f,
-    )
 }
 
 /**
  * Resolves the solid base background color for a [CutoutFill] to sit on top of.
- * If the user configured an AppIcon fallback or a target base color, that is used;
- * otherwise defaults to OLED Black (#000000).
+ * Defaults to OLED Black (#000000), or the configured fallback if Solid AppIcon is chosen.
  */
 @Composable
 fun CutoutFill.resolveBaseColor(appColor: Color? = null, adaptiveColor: Color? = null): Color = when (this) {
-    is CutoutFill.AppFade -> {
-        baseColor.resolve(appColor, adaptiveColor).copy(alpha = 1f)
-    }
     is CutoutFill.Solid -> when (val spec = color) {
         is ColorSpec.AppIcon -> when (spec.fallback) {
             AppColorFallback.DYNAMIC_THEME -> dynamicRole(DynamicRole.PRIMARY)

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/CutoutColors.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/CutoutColors.kt
@@ -11,10 +11,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalContext
+import com.ekoehler.expressivecutout.data.AppColorFallback
 import com.ekoehler.expressivecutout.data.ColorSpec
 import com.ekoehler.expressivecutout.data.CutoutColor
 import com.ekoehler.expressivecutout.data.CutoutFill
 import com.ekoehler.expressivecutout.data.DynamicRole
+import com.ekoehler.expressivecutout.data.FadeDirection
 import com.ekoehler.expressivecutout.data.GradientDirection
 
 /** Fallback accent used for dynamic colours before Android 12 (no Material You). */
@@ -23,35 +25,165 @@ private val DYNAMIC_FALLBACK = Color(0xFF60A5FA)
 /**
  * Resolve a [CutoutColor] to a concrete [Color]. [Dynamic] reads the system Material You accent
  * (dark/light to match the phone) on Android 12+, and falls back to a fixed accent below that.
- * Works both inside and outside a MaterialTheme, so the overlay and the in-app preview agree.
+ * [AppIcon] resolves to [appColor] or the configured fallback strategy if no app color is present.
  */
 @Composable
-fun CutoutColor.resolve(): Color = when (this) {
+fun CutoutColor.resolve(appColor: Color? = null, adaptiveColor: Color? = null): Color = when (this) {
     is CutoutColor.Solid -> Color(argb)
     is CutoutColor.Dynamic -> dynamicRole(role)
+    is CutoutColor.AppIcon -> {
+        appColor ?: when (fallback) {
+            AppColorFallback.DYNAMIC_THEME -> dynamicRole(DynamicRole.PRIMARY)
+            AppColorFallback.OLED_BLACK -> Color(0xFF000000L)
+            AppColorFallback.ADAPTIVE -> adaptiveColor ?: dynamicRole(DynamicRole.PRIMARY)
+        }
+    }
 }
 
 /** Resolve a single [ColorSpec] to a concrete [Color], applying its opacity. */
 @Composable
-fun ColorSpec.resolve(): Color = when (this) {
+fun ColorSpec.resolve(appColor: Color? = null, adaptiveColor: Color? = null): Color = when (this) {
     is ColorSpec.Fixed -> Color(argb)
     is ColorSpec.Dynamic -> dynamicRole(role).copy(alpha = alpha)
+    is ColorSpec.AppIcon -> {
+        val base = appColor ?: when (fallback) {
+            AppColorFallback.DYNAMIC_THEME -> dynamicRole(DynamicRole.PRIMARY)
+            AppColorFallback.OLED_BLACK -> Color(0xFF000000L)
+            AppColorFallback.ADAPTIVE -> adaptiveColor ?: dynamicRole(DynamicRole.PRIMARY)
+        }
+        base.copy(alpha = alpha)
+    }
+}
+
+/** Non-composable variant of [CutoutColor.resolve] allowing a custom dynamic color resolver for testing. */
+fun CutoutColor.resolveColor(
+    appColor: Color? = null,
+    dynamicResolver: (DynamicRole) -> Color = { DYNAMIC_FALLBACK },
+    adaptiveColor: Color? = null,
+): Color = when (this) {
+    is CutoutColor.Solid -> Color(argb)
+    is CutoutColor.Dynamic -> dynamicResolver(role)
+    is CutoutColor.AppIcon -> {
+        appColor ?: when (fallback) {
+            AppColorFallback.DYNAMIC_THEME -> dynamicResolver(DynamicRole.PRIMARY)
+            AppColorFallback.OLED_BLACK -> Color(0xFF000000L)
+            AppColorFallback.ADAPTIVE -> adaptiveColor ?: dynamicResolver(DynamicRole.PRIMARY)
+        }
+    }
+}
+
+/** Non-composable variant of [ColorSpec.resolve] allowing a custom dynamic color resolver for testing. */
+fun ColorSpec.resolveColor(
+    appColor: Color? = null,
+    dynamicResolver: (DynamicRole) -> Color = { DYNAMIC_FALLBACK },
+    adaptiveColor: Color? = null,
+): Color = when (this) {
+    is ColorSpec.Fixed -> Color(argb)
+    is ColorSpec.Dynamic -> dynamicResolver(role).copy(alpha = alpha)
+    is ColorSpec.AppIcon -> {
+        val base = appColor ?: when (fallback) {
+            AppColorFallback.DYNAMIC_THEME -> dynamicResolver(DynamicRole.PRIMARY)
+            AppColorFallback.OLED_BLACK -> Color(0xFF000000L)
+            AppColorFallback.ADAPTIVE -> adaptiveColor ?: dynamicResolver(DynamicRole.PRIMARY)
+        }
+        base.copy(alpha = alpha)
+    }
 }
 
 /**
  * Resolve a [CutoutFill] to the [Brush] painted behind the island. A [CutoutFill.Solid] is a flat
- * [SolidColor]; a [CutoutFill.Gradient] becomes a two-stop gradient in its chosen direction.
+ * [SolidColor]; a [CutoutFill.Gradient] becomes a two-stop gradient in its chosen direction;
+ * a [CutoutFill.AppFade] renders a directional fade with solid percentage into the base color.
  */
 @Composable
-fun CutoutFill.resolveBrush(): Brush = when (this) {
-    is CutoutFill.Solid -> SolidColor(color.resolve())
+fun CutoutFill.resolveBrush(appColor: Color? = null, adaptiveColor: Color? = null): Brush = when (this) {
+    is CutoutFill.Solid -> SolidColor(color.resolve(appColor, adaptiveColor))
     is CutoutFill.Gradient -> {
-        val colors = listOf(start.resolve(), end.resolve())
+        val startColor = start.resolve(appColor, adaptiveColor).let { it.copy(alpha = it.alpha * opacity) }
+        val endColor = end.resolve(appColor, adaptiveColor).let { it.copy(alpha = it.alpha * opacity) }
+        val colors = listOf(startColor, endColor)
         when (direction) {
             GradientDirection.VERTICAL -> Brush.verticalGradient(colors)
             GradientDirection.HORIZONTAL -> Brush.horizontalGradient(colors)
             GradientDirection.DIAGONAL -> Brush.linearGradient(colors)
         }
+    }
+    is CutoutFill.AppFade -> {
+        val resolvedApp = appColorSpec.resolve(appColor, adaptiveColor).let { it.copy(alpha = it.alpha * opacity) }
+        val resolvedBase = baseColor.resolve(appColor, adaptiveColor).let { it.copy(alpha = it.alpha * opacity) }
+        val gFrac = (solidPercent / 100f).coerceIn(0f, 1f)
+        val fFrac = (fadeDistance / 100f).coerceIn(0f, 1f)
+
+        val stops = when (direction) {
+            FadeDirection.LEFT_TO_RIGHT -> {
+                val fadeEnd = (gFrac + fFrac).coerceIn(0f, 1f)
+                if (gFrac <= 0f && fFrac <= 0f) {
+                    arrayOf(0.0f to resolvedBase, 1.0f to resolvedBase)
+                } else if (gFrac >= 1f) {
+                    arrayOf(0.0f to resolvedApp, 1.0f to resolvedApp)
+                } else if (fFrac <= 0f) {
+                    // Harsh break at gFrac
+                    arrayOf(
+                        0.0f to resolvedApp,
+                        gFrac to resolvedApp,
+                        gFrac to resolvedBase,
+                        1.0f to resolvedBase,
+                    )
+                } else {
+                    if (gFrac <= 0f) {
+                        if (fadeEnd >= 1f) {
+                            arrayOf(0.0f to resolvedApp, 1.0f to resolvedBase)
+                        } else {
+                            arrayOf(0.0f to resolvedApp, fadeEnd to resolvedBase, 1.0f to resolvedBase)
+                        }
+                    } else if (fadeEnd >= 1f) {
+                        arrayOf(0.0f to resolvedApp, gFrac to resolvedApp, 1.0f to resolvedBase)
+                    } else {
+                        arrayOf(
+                            0.0f to resolvedApp,
+                            gFrac to resolvedApp,
+                            fadeEnd to resolvedBase,
+                            1.0f to resolvedBase,
+                        )
+                    }
+                }
+            }
+            FadeDirection.RIGHT_TO_LEFT -> {
+                val appStart = (1f - gFrac).coerceIn(0f, 1f)
+                val fadeStart = (1f - gFrac - fFrac).coerceIn(0f, 1f)
+                if (gFrac <= 0f && fFrac <= 0f) {
+                    arrayOf(0.0f to resolvedBase, 1.0f to resolvedBase)
+                } else if (gFrac >= 1f) {
+                    arrayOf(0.0f to resolvedApp, 1.0f to resolvedApp)
+                } else if (fFrac <= 0f) {
+                    // Harsh break at appStart
+                    arrayOf(
+                        0.0f to resolvedBase,
+                        appStart to resolvedBase,
+                        appStart to resolvedApp,
+                        1.0f to resolvedApp,
+                    )
+                } else {
+                    if (gFrac <= 0f) {
+                        if (fadeStart <= 0f) {
+                            arrayOf(0.0f to resolvedBase, 1.0f to resolvedApp)
+                        } else {
+                            arrayOf(0.0f to resolvedBase, fadeStart to resolvedBase, 1.0f to resolvedApp)
+                        }
+                    } else if (fadeStart <= 0f) {
+                        arrayOf(0.0f to resolvedBase, appStart to resolvedApp, 1.0f to resolvedApp)
+                    } else {
+                        arrayOf(
+                            0.0f to resolvedBase,
+                            fadeStart to resolvedBase,
+                            appStart to resolvedApp,
+                            1.0f to resolvedApp,
+                        )
+                    }
+                }
+            }
+        }
+        Brush.horizontalGradient(colorStops = stops)
     }
 }
 
@@ -60,14 +192,67 @@ fun CutoutFill.resolveBrush(): Brush = when (this) {
  * should be light or dark. A gradient reports the midpoint of its two stops.
  */
 @Composable
-fun CutoutFill.representativeColor(): Color = when (this) {
-    is CutoutFill.Solid -> color.resolve()
-    is CutoutFill.Gradient -> lerp(start.resolve(), end.resolve(), 0.5f)
+fun CutoutFill.representativeColor(appColor: Color? = null, adaptiveColor: Color? = null): Color = when (this) {
+    is CutoutFill.Solid -> color.resolve(appColor, adaptiveColor)
+    is CutoutFill.Gradient -> lerp(
+        start.resolve(appColor, adaptiveColor).let { it.copy(alpha = it.alpha * opacity) },
+        end.resolve(appColor, adaptiveColor).let { it.copy(alpha = it.alpha * opacity) },
+        0.5f,
+    )
+    is CutoutFill.AppFade -> lerp(
+        appColorSpec.resolve(appColor, adaptiveColor).let { it.copy(alpha = it.alpha * opacity) },
+        baseColor.resolve(appColor, adaptiveColor).let { it.copy(alpha = it.alpha * opacity) },
+        0.5f,
+    )
+}
+
+/**
+ * Resolves the solid base background color for a [CutoutFill] to sit on top of.
+ * If the user configured an AppIcon fallback or a target base color, that is used;
+ * otherwise defaults to OLED Black (#000000).
+ */
+@Composable
+fun CutoutFill.resolveBaseColor(appColor: Color? = null, adaptiveColor: Color? = null): Color = when (this) {
+    is CutoutFill.AppFade -> {
+        baseColor.resolve(appColor, adaptiveColor).copy(alpha = 1f)
+    }
+    is CutoutFill.Solid -> when (val spec = color) {
+        is ColorSpec.AppIcon -> when (spec.fallback) {
+            AppColorFallback.DYNAMIC_THEME -> dynamicRole(DynamicRole.PRIMARY)
+            AppColorFallback.OLED_BLACK -> Color(0xFF000000L)
+            AppColorFallback.ADAPTIVE -> adaptiveColor ?: dynamicRole(DynamicRole.PRIMARY)
+        }
+        else -> Color(0xFF000000L)
+    }
+    is CutoutFill.Gradient -> Color(0xFF000000L)
+}
+
+/**
+ * Resolves the primary accent/branding color for an [IslandEvent].
+ * Order of precedence:
+ * 1. User-configured per-event [IslandEvent.colorOverride]
+ * 2. System Material You dynamic color when [IslandEvent.useThemeColor] is enabled
+ * 3. Extracted [IslandEvent.appColor] for apps/notifications
+ * 4. Built-in [IslandEvent.accent] default color
+ */
+fun IslandEvent.resolvePrimaryColor(dynamicResolver: (DynamicRole) -> Color = { DYNAMIC_FALLBACK }): Color = when {
+    colorOverride != null -> colorOverride.resolveColor(appColor, dynamicResolver)
+    useThemeColor -> dynamicResolver(themeColorRole)
+    appColor != null -> appColor
+    else -> accent
+}
+
+@Composable
+fun IslandEvent.primaryColor(): Color = when {
+    colorOverride != null -> colorOverride.resolve()
+    useThemeColor -> dynamicRole(themeColorRole)
+    appColor != null -> appColor
+    else -> accent
 }
 
 /** The Material You [role] colour (dark/light to match the phone) on Android 12+, else a fallback. */
 @Composable
-private fun dynamicRole(role: DynamicRole): Color {
+internal fun dynamicRole(role: DynamicRole): Color {
     val context = LocalContext.current
     val dark = isSystemInDarkTheme()
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
@@ -744,6 +744,8 @@ fun DynamicIsland(
                     shape = cornerShape(revealTopLeft, revealTopRight, revealBottomLeft, revealBottomRight),
                     appearance = appearance,
                     progress = expandProgress,
+                    appColor = shownEvent?.primaryColor(),
+                    adaptiveColor = shownEvent?.primaryColor(),
                 ) {
                     Crossfade(targetState = isExpanded, animationSpec = tween(scaled(150)), label = "islandContent") { showExpanded ->
                         if (emptyPill) {
@@ -864,6 +866,7 @@ fun IslandPreview(
     showActions: Boolean = true,
     collapsedHeightDp: Int = IslandLayout.DEFAULT_COLLAPSED.heightDp,
 ) {
+    val eventPrimaryColor = event.primaryColor()
     IslandSurface(
         modifier = Modifier.size(width, heightDp.dp),
         shape = cornerShape(
@@ -875,6 +878,8 @@ fun IslandPreview(
         appearance = appearance,
         // A static preview shows one state outright, so snap the fill to it.
         progress = if (expanded) 1f else 0f,
+        appColor = eventPrimaryColor,
+        adaptiveColor = eventPrimaryColor,
     ) {
         if (expanded) {
             ExpandedContent(
@@ -906,33 +911,41 @@ private fun IslandSurface(
     shape: Shape,
     appearance: AppearanceSettings,
     progress: Float,
+    appColor: Color? = null,
+    adaptiveColor: Color? = null,
     content: @Composable () -> Unit,
 ) {
-    val normalBrush = appearance.backgroundNormal.resolveBrush()
-    val expandedBrush = appearance.backgroundExpanded.resolveBrush()
+    val normalBrush = appearance.backgroundNormal.resolveBrush(appColor, adaptiveColor)
+    val expandedBrush = appearance.backgroundExpanded.resolveBrush(appColor, adaptiveColor)
+    val normalBaseColor = appearance.backgroundNormal.resolveBaseColor(appColor, adaptiveColor)
+    val expandedBaseColor = appearance.backgroundExpanded.resolveBaseColor(appColor, adaptiveColor)
+    val currentBaseColor = lerp(normalBaseColor, expandedBaseColor, progress)
+
     val repColor = lerp(
-        appearance.backgroundNormal.representativeColor(),
-        appearance.backgroundExpanded.representativeColor(),
+        appearance.backgroundNormal.representativeColor(appColor, adaptiveColor),
+        appearance.backgroundExpanded.representativeColor(appColor, adaptiveColor),
         progress,
     )
 
     val contentColor = if (repColor.luminance() > 0.5f) PILL_TEXT_COLOR_DARK else PILL_TEXT_COLOR
     val border = if (appearance.strokeEnabled) {
-        BorderStroke(appearance.strokeWidthDp.dp, appearance.strokeColor.resolve())
+        val baseColor = appearance.strokeColor.resolve(appColor, adaptiveColor)
+        val strokeFinalColor = baseColor.copy(alpha = (baseColor.alpha * appearance.strokeOpacity).coerceIn(0f, 1f))
+        BorderStroke(appearance.strokeWidthDp.dp, strokeFinalColor)
     } else {
         null
     }
 
     Surface(
-        modifier = modifier,
+        modifier = modifier.background(currentBaseColor, shape),
         shape = shape,
-        color = Color.Transparent,
+        color = currentBaseColor,
         contentColor = contentColor,
         shadowElevation = if (appearance.shadowEnabled) 6.dp else 0.dp,
         tonalElevation = 0.dp,
         border = border,
     ) {
-        Box(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize().background(currentBaseColor)) {
             Box(modifier = Modifier.fillMaxSize().background(normalBrush))
             if (progress > 0f) {
                 Box(
@@ -2976,7 +2989,7 @@ private fun IconBadge(
             badgeColor = container.resolve()
             glyphColor = when (container) {
                 is CutoutColor.Dynamic -> onDynamicRole(container.role)
-                is CutoutColor.Solid ->
+                is CutoutColor.Solid, is CutoutColor.AppIcon ->
                     if (badgeColor.luminance() > 0.5f) PILL_TEXT_COLOR_DARK else PILL_TEXT_COLOR
             }
         }

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
@@ -927,7 +927,8 @@ private fun IslandSurface(
         progress,
     )
 
-    val contentColor = if (repColor.luminance() > 0.5f) PILL_TEXT_COLOR_DARK else PILL_TEXT_COLOR
+    val autoContentColor = if (repColor.luminance() > 0.5f) PILL_TEXT_COLOR_DARK else PILL_TEXT_COLOR
+    val contentColor = appearance.textColor?.resolve(appColor, adaptiveColor) ?: autoContentColor
     val border = if (appearance.strokeEnabled) {
         val baseColor = appearance.strokeColor.resolve(appColor, adaptiveColor)
         val strokeFinalColor = baseColor.copy(alpha = (baseColor.alpha * appearance.strokeOpacity).coerceIn(0f, 1f))

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/DynamicIsland.kt
@@ -946,17 +946,19 @@ private fun IslandSurface(
         tonalElevation = 0.dp,
         border = border,
     ) {
-        Box(modifier = Modifier.fillMaxSize().background(currentBaseColor)) {
-            Box(modifier = Modifier.fillMaxSize().background(normalBrush))
-            if (progress > 0f) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .graphicsLayer { alpha = progress }
-                        .background(expandedBrush),
-                )
+        CompositionLocalProvider(LocalContentColor provides contentColor) {
+            Box(modifier = Modifier.fillMaxSize().background(currentBaseColor)) {
+                Box(modifier = Modifier.fillMaxSize().background(normalBrush))
+                if (progress > 0f) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .graphicsLayer { alpha = progress }
+                            .background(expandedBrush),
+                    )
+                }
+                content()
             }
-            content()
         }
     }
 }

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IconResolver.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IconResolver.kt
@@ -87,31 +87,47 @@ class IconResolver(private val context: Context) {
         animatedIconEnabled: Map<SystemEventType, Boolean> = emptyMap(),
         animatedIconLoop: Map<SystemEventType, Boolean> = emptyMap(),
         eventColorOverrides: Map<SystemEventType, CutoutColor> = emptyMap(),
-    ): IslandEvent = when (signal) {
-        is CutoutSignal.Notification -> resolveNotification(
-            signal,
-            dynamicEventColor,
-            dynamicEventColorRole,
-            dynamicEventColorOpacity,
-        )
-        is CutoutSignal.System -> resolveSystem(
-            signal.type,
-            customIcons,
-            dynamicEventColor,
-            dynamicEventColorRole,
-            dynamicEventColorOpacity,
-            animatedIconEnabled,
-            animatedIconLoop,
-            eventColorOverrides,
-        )
-        is CutoutSignal.Music -> resolveMusic(signal, musicSettings)
-        is CutoutSignal.Call -> resolveCall(signal, phoneSettings)
-        is CutoutSignal.Timer -> resolveTimer(signal, timerSettings)
-        is CutoutSignal.Assistant -> resolveAssistant(signal, assistantSettings)
+    ): IslandEvent {
+        val packageName = when (signal) {
+            is CutoutSignal.Notification -> signal.packageName
+            is CutoutSignal.Music -> signal.packageName
+            is CutoutSignal.Call -> signal.packageName
+            is CutoutSignal.Timer -> signal.packageName
+            is CutoutSignal.Assistant -> signal.packageName
+            is CutoutSignal.System -> null
+        }
+        val appColor = packageName?.let { AppIconColorExtractor.extractAppColor(context, it) }
+
+        return when (signal) {
+            is CutoutSignal.Notification -> resolveNotification(
+                signal,
+                signal.packageName,
+                appColor,
+                dynamicEventColor,
+                dynamicEventColorRole,
+                dynamicEventColorOpacity,
+            )
+            is CutoutSignal.System -> resolveSystem(
+                signal.type,
+                customIcons,
+                dynamicEventColor,
+                dynamicEventColorRole,
+                dynamicEventColorOpacity,
+                animatedIconEnabled,
+                animatedIconLoop,
+                eventColorOverrides,
+            )
+            is CutoutSignal.Music -> resolveMusic(signal, signal.packageName, appColor, musicSettings)
+            is CutoutSignal.Call -> resolveCall(signal, signal.packageName, appColor, phoneSettings)
+            is CutoutSignal.Timer -> resolveTimer(signal, signal.packageName, appColor, timerSettings)
+            is CutoutSignal.Assistant -> resolveAssistant(signal, signal.packageName, appColor, assistantSettings)
+        }
     }
 
     private fun resolveNotification(
         signal: CutoutSignal.Notification,
+        packageName: String,
+        appColor: Color?,
         dynamicEventColor: Boolean,
         dynamicEventColorRole: DynamicRole,
         dynamicEventColorOpacity: Float,
@@ -140,6 +156,8 @@ class IconResolver(private val context: Context) {
             contentIntent = signal.contentIntent,
             notificationKey = signal.key,
             progressData = signal.progressData,
+            packageName = packageName,
+            appColor = appColor,
             actions = signal.actions.map { action ->
                 IslandAction(
                     label = action.title,
@@ -168,7 +186,12 @@ class IconResolver(private val context: Context) {
     /**
      * Turns a music signal into a renderable event, choosing between album art and the note glyph.
      */
-    private fun resolveMusic(signal: CutoutSignal.Music, settings: MusicTileSettings): IslandEvent {
+    private fun resolveMusic(
+        signal: CutoutSignal.Music,
+        packageName: String,
+        appColor: Color?,
+        settings: MusicTileSettings,
+    ): IslandEvent {
         // The collapsed pill normally shows album art; the note glyph stands in when the session
         // carries none (or the user turned art off). Deliberately not the player's launcher icon:
         // resolving that would mean asking the system which apps are installed.
@@ -181,6 +204,8 @@ class IconResolver(private val context: Context) {
             label = title ?: context.getString(DynamicTile.MUSIC.labelRes),
             detail = signal.artist?.takeIf { it.isNotBlank() },
             accent = Color(DynamicTile.MUSIC.accent),
+            packageName = packageName,
+            appColor = appColor,
             contentIntent = signal.contentIntent,
             media = MediaTileOptions(
                 showAlbumArt = settings.showAlbumArt,
@@ -199,7 +224,12 @@ class IconResolver(private val context: Context) {
      * Turns a call signal into a renderable event. The caller photo is not resolved here; it
      * arrives live on [OnCallBus] instead.
      */
-    private fun resolveCall(signal: CutoutSignal.Call, settings: PhoneTileSettings): IslandEvent {
+    private fun resolveCall(
+        signal: CutoutSignal.Call,
+        packageName: String,
+        appColor: Color?,
+        settings: PhoneTileSettings,
+    ): IslandEvent {
         // The live contact photo comes from OnCallBus; this icon is only the no-photo fallback, so a
         // person avatar reads as "a contact" (the Google-dialer default look) better than a handset.
         return IslandEvent(
@@ -207,6 +237,8 @@ class IconResolver(private val context: Context) {
             icon = IslandIcon.Vector(Icons.Rounded.Person),
             label = signal.callerLabel,
             accent = Color(DynamicTile.PHONE.accent),
+            packageName = packageName,
+            appColor = appColor,
             iconContainerColor = settings.iconContainerColor,
             contentIntent = signal.contentIntent,
             // Deliberately no notificationKey: a swipe should hide the pill, never cancel the
@@ -249,13 +281,20 @@ class IconResolver(private val context: Context) {
      * Turns a timer signal into a renderable event, falling back to the tile's own label when the
      * clock app names none.
      */
-    private fun resolveTimer(signal: CutoutSignal.Timer, settings: TimerTileSettings): IslandEvent {
+    private fun resolveTimer(
+        signal: CutoutSignal.Timer,
+        packageName: String,
+        appColor: Color?,
+        settings: TimerTileSettings,
+    ): IslandEvent {
         return IslandEvent(
             id = idGenerator.incrementAndGet(),
             icon = IslandIcon.Vector(DynamicTile.TIMER.defaultIcon),
             label = signal.label?.takeIf { it.isNotBlank() }
                 ?: context.getString(DynamicTile.TIMER.labelRes),
             accent = Color(DynamicTile.TIMER.accent),
+            packageName = packageName,
+            appColor = appColor,
             iconContainerColor = settings.iconContainerColor,
             contentIntent = signal.contentIntent,
             // Deliberately no notificationKey: a swipe should hide the pill, never cancel the clock's
@@ -273,7 +312,12 @@ class IconResolver(private val context: Context) {
      * Turns an assistant signal into a renderable event, preferring the spoken title over the body
      * text.
      */
-    private fun resolveAssistant(signal: CutoutSignal.Assistant, settings: AssistantTileSettings): IslandEvent {
+    private fun resolveAssistant(
+        signal: CutoutSignal.Assistant,
+        packageName: String,
+        appColor: Color?,
+        settings: AssistantTileSettings,
+    ): IslandEvent {
         val defaultLabel = context.getString(DynamicTile.ASSISTANT.labelRes)
         val rawTitle = signal.title?.takeIf { it.isNotBlank() }
         val rawText = signal.text?.takeIf { it.isNotBlank() }
@@ -302,6 +346,8 @@ class IconResolver(private val context: Context) {
             label = label,
             detail = answerText,
             accent = Color(DynamicTile.ASSISTANT.accent),
+            packageName = packageName,
+            appColor = appColor,
             iconContainerColor = settings.iconContainerColor,
             contentIntent = signal.contentIntent,
             initiallyExpanded = settings.displayAnswerInCutout,

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandEvent.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandEvent.kt
@@ -132,7 +132,11 @@ data class IslandEvent(
      * Contains the progress of this notification if it is a progress one.
      * Is null otherwise
      */
-    val progressData: ProgressData? = null
+    val progressData: ProgressData? = null,
+    /** The package name of the app that posted this event, if any. */
+    val packageName: String? = null,
+    /** The primary branding color extracted from the posting app's default launcher icon, if any. */
+    val appColor: Color? = null,
 )
 
 /** Which parts of the assistant tile to render (display text, max height). */

--- a/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/overlay/IslandOverlayController.kt
@@ -276,6 +276,7 @@ class IslandOverlayController(private val context: Context) {
             label = context.getString(R.string.preview_label),
             detail = context.getString(R.string.preview_detail),
             accent = Color(0xFF60A5FA),
+            appColor = Color(0xFF60A5FA),
         )
     }
 

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
@@ -806,6 +806,10 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         appearancePreferences.setStrokeWidth(widthDp)
     }
 
+    fun setStrokeOpacity(opacity: Float) = viewModelScope.launch {
+        appearancePreferences.setStrokeOpacity(opacity)
+    }
+
     fun setStrokeColor(color: CutoutColor) = viewModelScope.launch {
         appearancePreferences.setStrokeColor(color)
     }

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/AppViewModel.kt
@@ -814,6 +814,10 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         appearancePreferences.setStrokeColor(color)
     }
 
+    fun setTextColor(color: CutoutColor?) = viewModelScope.launch {
+        appearancePreferences.setTextColor(color)
+    }
+
     fun setBackgroundNormal(fill: CutoutFill) = viewModelScope.launch {
         appearancePreferences.setBackgroundNormal(fill)
     }

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/components/ColorPickerCard.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/components/ColorPickerCard.kt
@@ -26,9 +26,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ekoehler.expressivecutout.R
+import com.ekoehler.expressivecutout.data.AppColorFallback
 import com.ekoehler.expressivecutout.data.CutoutColor
 import com.ekoehler.expressivecutout.data.DynamicRole
 import com.ekoehler.expressivecutout.data.RecentColorPreferences
@@ -56,8 +60,64 @@ val DEFAULT_PRESET_COLORS: List<Long> = listOf(
 /** The Material You dynamic roles [ColorPickerCard] offers by default, in display order. */
 private val DEFAULT_DYNAMIC_ROLES = listOf(DynamicRole.PRIMARY, DynamicRole.SECONDARY, DynamicRole.TERTIARY)
 
+/**
+ * Reusable segmented row for choosing fallback behavior when app icon color is selected
+ * but no active notification provides an app icon.
+ */
 @Composable
-fun ColorPickerCard (
+fun AppColorFallbackRow(
+    fallback: AppColorFallback,
+    onSelect: (AppColorFallback) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val fallbackOptions = listOf(
+        AppColorFallback.ADAPTIVE to R.string.app_color_fallback_adaptive,
+        AppColorFallback.DYNAMIC_THEME to R.string.app_color_fallback_dynamic,
+        AppColorFallback.OLED_BLACK to R.string.app_color_fallback_oled,
+    )
+
+    Column(
+        modifier = modifier.padding(top = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.app_color_fallback_title),
+            style = MaterialTheme.typography.titleSmall,
+        )
+        ExpressiveSegmentedRow(
+            options = fallbackOptions.map { stringResource(it.second) },
+            selectedIndex = fallbackOptions.indexOfFirst { it.first == fallback }.coerceAtLeast(0),
+            onSelect = { index -> onSelect(fallbackOptions[index].first) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+/**
+ * Contextual description card showing user what the active color swatch selection does.
+ */
+@Composable
+fun ColorSelectionTooltip(
+    text: String?,
+    modifier: Modifier = Modifier,
+) {
+    if (text == null) return
+    Card(
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)),
+        modifier = modifier.fillMaxWidth().padding(top = 2.dp),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+        )
+    }
+}
+
+@Composable
+fun ColorPickerCard(
     label: String? = null,
     selected: CutoutColor?,
     onSelect: (CutoutColor?) -> Unit,
@@ -66,13 +126,11 @@ fun ColorPickerCard (
     presetColors: List<Long> = DEFAULT_PRESET_COLORS,
     dynamicRoles: List<DynamicRole> = DEFAULT_DYNAMIC_ROLES,
     roundedCorners: Dp = 24.dp,
-    proposeOledBlack: Boolean = true
+    allowAppIcon: Boolean = true,
 ) {
     var showPicker by remember { mutableStateOf(false) }
-    // A Solid colour that isn't one of the presets is the user's own custom pick.
     val customArgb = (selected as? CutoutColor.Solid)?.argb
         ?.takeIf { argb -> presetColors.none { it == argb } }
-    // Seed the picker with whatever colour is active right now.
     val currentColor = selected?.resolve() ?: defaultColor ?: Color.White
 
     val context = LocalContext.current
@@ -100,7 +158,6 @@ fun ColorPickerCard (
                 modifier = Modifier
                     .fillMaxWidth()
                     .horizontalScroll(rememberScrollState())
-                    // Breathing room so the selected swatch's enlarged ring isn't clipped at the edges.
                     .padding(horizontal = 4.dp, vertical = 3.dp),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
@@ -116,6 +173,20 @@ fun ColorPickerCard (
                         onClick = { onSelect(null) },
                     )
                 }
+
+                if (allowAppIcon) {
+                    ColorSwatch(
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        selected = selected is CutoutColor.AppIcon,
+                        badgePainter = painterResource(R.drawable.ic_play_store),
+                        badgeDescription = stringResource(R.string.cd_color_app_icon),
+                        onClick = {
+                            val currentFallback = (selected as? CutoutColor.AppIcon)?.fallback ?: AppColorFallback.ADAPTIVE
+                            onSelect(CutoutColor.AppIcon(currentFallback))
+                        },
+                    )
+                }
+
                 dynamicRoles.forEach { role ->
                     ColorSwatch(
                         color = CutoutColor.Dynamic(role).resolve(),
@@ -144,6 +215,27 @@ fun ColorPickerCard (
                     )
                 }
             }
+
+            AnimatedVisibility(visible = allowAppIcon && selected is CutoutColor.AppIcon) {
+                val fallback = (selected as? CutoutColor.AppIcon)?.fallback ?: AppColorFallback.ADAPTIVE
+                AppColorFallbackRow(
+                    fallback = fallback,
+                    onSelect = { onSelect(CutoutColor.AppIcon(it)) },
+                )
+            }
+
+            val tooltipText = when {
+                selected == null -> stringResource(R.string.tooltip_default_reset)
+                selected is CutoutColor.AppIcon -> stringResource(R.string.tooltip_app_icon)
+                selected is CutoutColor.Dynamic && selected.role == DynamicRole.PRIMARY -> stringResource(R.string.tooltip_dynamic_primary)
+                selected is CutoutColor.Dynamic && selected.role == DynamicRole.SECONDARY -> stringResource(R.string.tooltip_dynamic_secondary)
+                selected is CutoutColor.Dynamic && selected.role == DynamicRole.TERTIARY -> stringResource(R.string.tooltip_dynamic_tertiary)
+                selected is CutoutColor.Solid && (selected.argb and 0xFFFFFFL == 0x000000L) -> stringResource(R.string.tooltip_oled_black)
+                selected is CutoutColor.Solid && customArgb != null -> stringResource(R.string.tooltip_custom_color)
+                selected is CutoutColor.Solid -> stringResource(R.string.tooltip_preset_color)
+                else -> null
+            }
+            ColorSelectionTooltip(text = tooltipText)
         }
     }
 

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/components/ColorPickerCard.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/components/ColorPickerCard.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -78,12 +80,18 @@ fun AppColorFallbackRow(
 
     Column(
         modifier = modifier.padding(top = 4.dp),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         Text(
             text = stringResource(R.string.app_color_fallback_title),
             style = MaterialTheme.typography.titleSmall,
         )
+        Text(
+            text = stringResource(R.string.app_color_fallback_desc),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(2.dp))
         ExpressiveSegmentedRow(
             options = fallbackOptions.map { stringResource(it.second) },
             selectedIndex = fallbackOptions.indexOfFirst { it.first == fallback }.coerceAtLeast(0),

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/Appearance/BackgroundScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/Appearance/BackgroundScreen.kt
@@ -19,9 +19,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -31,7 +29,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -46,7 +43,6 @@ import com.ekoehler.expressivecutout.data.AppColorFallback
 import com.ekoehler.expressivecutout.data.ColorSpec
 import com.ekoehler.expressivecutout.data.CutoutFill
 import com.ekoehler.expressivecutout.data.DynamicRole
-import com.ekoehler.expressivecutout.data.FadeDirection
 import com.ekoehler.expressivecutout.data.GradientDirection
 import com.ekoehler.expressivecutout.overlay.resolve
 import com.ekoehler.expressivecutout.overlay.resolveBaseColor
@@ -79,7 +75,7 @@ private val PresetArgbs = NeutralColors.map { it.first } + AccentColors
 
 /**
  * "Background" screen (reached from the Appearance screen). The collapsed ("normal") and expanded
- * cutout each get their own fill — a solid colour, a two-colour gradient, or an app-adaptive fade.
+ * cutout each get their own fill — a solid colour or a two-colour gradient.
  */
 @Composable
 internal fun BackgroundScreen(
@@ -119,7 +115,7 @@ internal fun BackgroundScreen(
     }
 }
 
-/** The fill editor for one state: a Solid/Gradient/AppFade switch and the matching controls. */
+/** The fill editor for one state: a Solid/Gradient switch and the matching controls. */
 @Composable
 private fun FillPickerCard(
     selected: CutoutFill,
@@ -128,7 +124,6 @@ private fun FillPickerCard(
     val modeIndex = when (selected) {
         is CutoutFill.Solid -> 0
         is CutoutFill.Gradient -> 1
-        is CutoutFill.AppFade -> 2
     }
 
     Card(
@@ -144,7 +139,6 @@ private fun FillPickerCard(
                 options = listOf(
                     stringResource(R.string.label_solid),
                     stringResource(R.string.label_gradient),
-                    stringResource(R.string.label_app_fade),
                 ),
                 selectedIndex = modeIndex,
                 onSelect = { index ->
@@ -153,7 +147,6 @@ private fun FillPickerCard(
                             val color = when (selected) {
                                 is CutoutFill.Solid -> selected.color
                                 is CutoutFill.Gradient -> selected.start
-                                is CutoutFill.AppFade -> selected.appColorSpec
                             }
                             onSelect(CutoutFill.Solid(color))
                         }
@@ -161,7 +154,6 @@ private fun FillPickerCard(
                             val start = when (selected) {
                                 is CutoutFill.Solid -> selected.color
                                 is CutoutFill.Gradient -> selected.start
-                                is CutoutFill.AppFade -> selected.appColorSpec
                             }
                             onSelect(
                                 CutoutFill.Gradient(
@@ -171,25 +163,12 @@ private fun FillPickerCard(
                                 )
                             )
                         }
-                        2 -> {
-                            onSelect(
-                                CutoutFill.AppFade(
-                                    appColorSpec = ColorSpec.AppIcon(),
-                                    baseColor = ColorSpec.Fixed(OledBlackArgb),
-                                    direction = FadeDirection.LEFT_TO_RIGHT,
-                                    solidPercent = 30,
-                                )
-                            )
-                        }
                     }
                 },
                 modifier = Modifier.fillMaxWidth(),
             )
 
             when (selected) {
-                is CutoutFill.AppFade -> {
-                    AppFadeControls(fade = selected, onSelect = onSelect)
-                }
                 is CutoutFill.Gradient -> {
                     GradientControls(gradient = selected, onSelect = onSelect)
                 }
@@ -205,111 +184,33 @@ private fun FillPickerCard(
     }
 }
 
-/** Controls for directional App Fade background mode. */
-@Composable
-private fun AppFadeControls(
-    fade: CutoutFill.AppFade,
-    onSelect: (CutoutFill) -> Unit,
-) {
-    val baseColor = fade.resolveBaseColor(PreviewAccent)
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(56.dp)
-            .clip(RoundedCornerShape(16.dp))
-            .background(baseColor)
-            .background(fade.resolveBrush(PreviewAccent)),
-    )
-
-    Text(
-        text = stringResource(R.string.fade_direction),
-        style = MaterialTheme.typography.titleSmall,
-    )
-    ExpressiveSegmentedRow(
-        options = listOf(
-            stringResource(R.string.fade_left_to_right),
-            stringResource(R.string.fade_right_to_left),
-        ),
-        selectedIndex = if (fade.direction == FadeDirection.LEFT_TO_RIGHT) 0 else 1,
-        onSelect = {
-            onSelect(fade.copy(direction = if (it == 0) FadeDirection.LEFT_TO_RIGHT else FadeDirection.RIGHT_TO_LEFT))
-        },
-        modifier = Modifier.fillMaxWidth(),
-    )
-
-    AdjustableSlider(
-        label = stringResource(R.string.fade_gradient_distance),
-        valueText = "${fade.solidPercent}%",
-        value = fade.solidPercent.toFloat(),
-        valueRange = 0f..100f,
-        step = 5f,
-        onValueChange = { onSelect(fade.copy(solidPercent = it.roundToInt())) },
-        onCommit = {},
-    )
-
-    AdjustableSlider(
-        label = stringResource(R.string.fade_distance),
-        valueText = "${fade.fadeDistance}%",
-        value = fade.fadeDistance.toFloat(),
-        valueRange = 0f..100f,
-        step = 5f,
-        onValueChange = { onSelect(fade.copy(fadeDistance = it.roundToInt())) },
-        onCommit = {},
-    )
-
-    AdjustableSlider(
-        label = stringResource(R.string.opacity),
-        valueText = "${(fade.opacity * 100).roundToInt()}%",
-        value = fade.opacity,
-        valueRange = 0f..1f,
-        step = 0.05f,
-        onValueChange = { onSelect(fade.copy(opacity = it)) },
-        onCommit = {},
-    )
-
-    AppColorFallbackRow(
-        fallback = fade.appColorSpec.fallback,
-        onSelect = { onSelect(fade.copy(appColorSpec = fade.appColorSpec.copy(fallback = it))) },
-    )
-
-    Text(
-        text = stringResource(R.string.fade_base_color),
-        style = MaterialTheme.typography.titleSmall,
-    )
-    ColorSpecPicker(
-        spec = fade.baseColor,
-        onChange = { onSelect(fade.copy(baseColor = it)) },
-        allowAppIcon = false,
-    )
-}
-
 /** A gradient preview strip, start/end colour pickers and a direction selector. */
 @Composable
 private fun GradientControls(
     gradient: CutoutFill.Gradient,
     onSelect: (CutoutFill) -> Unit,
 ) {
-    val baseColor = gradient.resolveBaseColor()
+    val baseColor = gradient.resolveBaseColor(PreviewAccent, PreviewAccent)
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .height(56.dp)
             .clip(RoundedCornerShape(16.dp))
             .background(baseColor)
-            .background(gradient.resolveBrush()),
+            .background(gradient.resolveBrush(PreviewAccent, PreviewAccent)),
     )
 
     Text(text = stringResource(R.string.gradient_start), style = MaterialTheme.typography.titleSmall)
     ColorSpecPicker(
         spec = gradient.start,
         onChange = { onSelect(gradient.copy(start = it)) },
-        allowAppIcon = false,
+        allowAppIcon = true,
     )
     Text(text = stringResource(R.string.gradient_end), style = MaterialTheme.typography.titleSmall)
     ColorSpecPicker(
         spec = gradient.end,
         onChange = { onSelect(gradient.copy(end = it)) },
-        allowAppIcon = false,
+        allowAppIcon = true,
     )
 
     Text(

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/Appearance/BackgroundScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/Appearance/BackgroundScreen.kt
@@ -3,7 +3,6 @@ package com.ekoehler.expressivecutout.ui.screen
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,22 +17,18 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AutoAwesome
-import androidx.compose.material.icons.rounded.DarkMode
-import androidx.compose.material.icons.rounded.LightMode
-import androidx.compose.material.icons.rounded.Notifications
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -41,31 +36,34 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ekoehler.expressivecutout.R
+import com.ekoehler.expressivecutout.core.IslandPreviewBus
+import com.ekoehler.expressivecutout.data.AppColorFallback
 import com.ekoehler.expressivecutout.data.ColorSpec
 import com.ekoehler.expressivecutout.data.CutoutFill
 import com.ekoehler.expressivecutout.data.DynamicRole
+import com.ekoehler.expressivecutout.data.FadeDirection
 import com.ekoehler.expressivecutout.data.GradientDirection
-import com.ekoehler.expressivecutout.data.RecentColorPreferences
-import com.ekoehler.expressivecutout.overlay.IslandEvent
-import com.ekoehler.expressivecutout.overlay.IslandIcon
 import com.ekoehler.expressivecutout.overlay.resolve
+import com.ekoehler.expressivecutout.overlay.resolveBaseColor
 import com.ekoehler.expressivecutout.overlay.resolveBrush
 import com.ekoehler.expressivecutout.ui.AppViewModel
-import com.ekoehler.expressivecutout.ui.components.ColorPickerCard
+import com.ekoehler.expressivecutout.ui.components.AppColorFallbackRow
+import com.ekoehler.expressivecutout.ui.components.ColorSelectionTooltip
 import com.ekoehler.expressivecutout.ui.components.ExpressiveSegmentedRow
-import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
-/** Accent used by the preview event, matching the sibling settings screens. */
-private val PREVIEW_ACCENT = Color(0xFF60A5FA)
+/** Accent used by preview swatches and fallback defaults. */
+private val PreviewAccent = Color(0xFF60A5FA)
+private const val OledBlackArgb = 0xFF000000L
+private const val DefaultGradientBlueArgb = 0xFF3B82F6L
 
 /** Neutral swatches offered first in every picker, with their content descriptions. */
-private val NEUTRAL_COLORS = listOf(
+private val NeutralColors = listOf(
     0xFF0A0A0AL to R.string.cd_color_black,
     0xFF444444L to R.string.cd_color_dark_grey,
     0xFFBBBBBBL to R.string.cd_color_light_grey,
@@ -73,21 +71,15 @@ private val NEUTRAL_COLORS = listOf(
 )
 
 /** Accent swatches shared with the other colour cards. */
-private val ACCENT_COLORS = listOf(
+private val AccentColors = listOf(
     0xFFEF4444L, 0xFFF59E0BL, 0xFF22C55EL, 0xFF3B82F6L, 0xFF8B5CF6L, 0xFFEC4899L,
 )
 
-/**
- * Every colour offered as a preset, flattened into one list so a recently-picked colour can be
- * tested against it and not shown twice.
- */
-private val PRESET_ARGBS = NEUTRAL_COLORS.map { it.first } + ACCENT_COLORS
+private val PresetArgbs = NeutralColors.map { it.first } + AccentColors
 
 /**
  * "Background" screen (reached from the Appearance screen). The collapsed ("normal") and expanded
- * cutout each get their own fill — a solid colour (Material You dynamic role, custom pick, or a
- * preset) or a two-colour gradient. When the two states differ the overlay cross-fades between
- * them as it expands/shrinks; a live preview at the top shows the state of the selected tab.
+ * cutout each get their own fill — a solid colour, a two-colour gradient, or an app-adaptive fade.
  */
 @Composable
 internal fun BackgroundScreen(
@@ -95,28 +87,15 @@ internal fun BackgroundScreen(
     contentPadding: PaddingValues,
 ) {
     val appearance by viewModel.appearance.collectAsStateWithLifecycle()
-    val layout by viewModel.layout.collectAsStateWithLifecycle()
-    val systemInDark = isSystemInDarkTheme()
-    var previewDark by remember { mutableStateOf(systemInDark) }
     // 0 = normal (collapsed), 1 = expanded.
     var tabIndex by rememberSaveable { mutableIntStateOf(0) }
     val expandedTab = tabIndex == 1
 
-    val previewLabel = stringResource(R.string.preview_label)
-    val previewDetail = stringResource(R.string.preview_detail)
-    val previewEvent = remember(previewLabel, previewDetail) {
-        IslandEvent(
-            id = 0L,
-            icon = IslandIcon.Vector(Icons.Rounded.Notifications),
-            label = previewLabel,
-            detail = previewDetail,
-            accent = PREVIEW_ACCENT,
-        )
-    }
-    val cutout = rememberTopCutout()
-    val dims = if (expandedTab) layout.expanded else layout.collapsed
     val currentFill = if (expandedTab) appearance.backgroundExpanded else appearance.backgroundNormal
     val onSelect: (CutoutFill) -> Unit = if (expandedTab) viewModel::setBackgroundExpanded else viewModel::setBackgroundNormal
+
+    // Mirror which tab is being edited (collapsed vs expanded) in the pinned live preview.
+    LaunchedEffect(tabIndex) { IslandPreviewBus.setExpandedPreview(tabIndex == 1) }
 
     Column(
         modifier = Modifier
@@ -125,40 +104,6 @@ internal fun BackgroundScreen(
             .padding(contentPadding),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = stringResource(R.string.appearance_preview),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            FilledTonalIconButton(onClick = { previewDark = !previewDark }) {
-                Icon(
-                    imageVector = if (previewDark) Icons.Rounded.LightMode else Icons.Rounded.DarkMode,
-                    contentDescription = stringResource(R.string.cd_toggle_preview_theme),
-                )
-            }
-        }
-
-        IslandPreviewPanel(
-            background = if (previewDark) Color(0xFF0B0B0C) else Color(0xFFEDEFF3),
-            cutout = cutout,
-            widthPercent = dims.widthPercent,
-            heightDp = dims.heightDp,
-            cornerTopLeftDp = dims.cornerTopLeftDp,
-            cornerTopRightDp = dims.cornerTopRightDp,
-            cornerBottomLeftDp = dims.cornerBottomLeftDp,
-            cornerBottomRightDp = dims.cornerBottomRightDp,
-            offsetXDp = dims.offsetXDp,
-            offsetYDp = dims.offsetYDp,
-            expanded = expandedTab,
-            event = previewEvent,
-            appearance = appearance,
-        )
-
         // Which state is being edited.
         ExpressiveSegmentedRow(
             options = listOf(
@@ -174,13 +119,17 @@ internal fun BackgroundScreen(
     }
 }
 
-/** The fill editor for one state: a Solid/Gradient switch and the matching controls. */
+/** The fill editor for one state: a Solid/Gradient/AppFade switch and the matching controls. */
 @Composable
 private fun FillPickerCard(
     selected: CutoutFill,
     onSelect: (CutoutFill) -> Unit,
 ) {
-    val isGradient = selected is CutoutFill.Gradient
+    val modeIndex = when (selected) {
+        is CutoutFill.Solid -> 0
+        is CutoutFill.Gradient -> 1
+        is CutoutFill.AppFade -> 2
+    }
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -195,35 +144,143 @@ private fun FillPickerCard(
                 options = listOf(
                     stringResource(R.string.label_solid),
                     stringResource(R.string.label_gradient),
+                    stringResource(R.string.label_app_fade),
                 ),
-                selectedIndex = if (isGradient) 1 else 0,
+                selectedIndex = modeIndex,
                 onSelect = { index ->
-                    when {
-                        index == 1 && selected !is CutoutFill.Gradient -> onSelect(
-                            CutoutFill.Gradient(
-                                start = (selected as? CutoutFill.Solid)?.color ?: ColorSpec.Fixed(0xFF0A0A0AL),
-                                end = ColorSpec.Fixed(0xFF3B82F6L),
-                                direction = GradientDirection.VERTICAL,
-                            ),
-                        )
-                        // Leaving gradient mode: keep the start colour as the solid fill.
-                        index == 0 && selected is CutoutFill.Gradient ->
-                            onSelect(CutoutFill.Solid(selected.start))
+                    when (index) {
+                        0 -> {
+                            val color = when (selected) {
+                                is CutoutFill.Solid -> selected.color
+                                is CutoutFill.Gradient -> selected.start
+                                is CutoutFill.AppFade -> selected.appColorSpec
+                            }
+                            onSelect(CutoutFill.Solid(color))
+                        }
+                        1 -> {
+                            val start = when (selected) {
+                                is CutoutFill.Solid -> selected.color
+                                is CutoutFill.Gradient -> selected.start
+                                is CutoutFill.AppFade -> selected.appColorSpec
+                            }
+                            onSelect(
+                                CutoutFill.Gradient(
+                                    start = start,
+                                    end = ColorSpec.Fixed(DefaultGradientBlueArgb),
+                                    direction = GradientDirection.VERTICAL,
+                                )
+                            )
+                        }
+                        2 -> {
+                            onSelect(
+                                CutoutFill.AppFade(
+                                    appColorSpec = ColorSpec.AppIcon(),
+                                    baseColor = ColorSpec.Fixed(OledBlackArgb),
+                                    direction = FadeDirection.LEFT_TO_RIGHT,
+                                    solidPercent = 30,
+                                )
+                            )
+                        }
                     }
                 },
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            if (selected is CutoutFill.Gradient) {
-                GradientControls(gradient = selected, onSelect = onSelect)
-            } else if (selected is CutoutFill.Solid) {
-                ColorSpecPicker(
-                    spec = selected.color,
-                    onChange = { onSelect(CutoutFill.Solid(it)) },
-                )
+            when (selected) {
+                is CutoutFill.AppFade -> {
+                    AppFadeControls(fade = selected, onSelect = onSelect)
+                }
+                is CutoutFill.Gradient -> {
+                    GradientControls(gradient = selected, onSelect = onSelect)
+                }
+                is CutoutFill.Solid -> {
+                    ColorSpecPicker(
+                        spec = selected.color,
+                        onChange = { onSelect(CutoutFill.Solid(it)) },
+                        allowAppIcon = true,
+                    )
+                }
             }
         }
     }
+}
+
+/** Controls for directional App Fade background mode. */
+@Composable
+private fun AppFadeControls(
+    fade: CutoutFill.AppFade,
+    onSelect: (CutoutFill) -> Unit,
+) {
+    val baseColor = fade.resolveBaseColor(PreviewAccent)
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(baseColor)
+            .background(fade.resolveBrush(PreviewAccent)),
+    )
+
+    Text(
+        text = stringResource(R.string.fade_direction),
+        style = MaterialTheme.typography.titleSmall,
+    )
+    ExpressiveSegmentedRow(
+        options = listOf(
+            stringResource(R.string.fade_left_to_right),
+            stringResource(R.string.fade_right_to_left),
+        ),
+        selectedIndex = if (fade.direction == FadeDirection.LEFT_TO_RIGHT) 0 else 1,
+        onSelect = {
+            onSelect(fade.copy(direction = if (it == 0) FadeDirection.LEFT_TO_RIGHT else FadeDirection.RIGHT_TO_LEFT))
+        },
+        modifier = Modifier.fillMaxWidth(),
+    )
+
+    AdjustableSlider(
+        label = stringResource(R.string.fade_gradient_distance),
+        valueText = "${fade.solidPercent}%",
+        value = fade.solidPercent.toFloat(),
+        valueRange = 0f..100f,
+        step = 5f,
+        onValueChange = { onSelect(fade.copy(solidPercent = it.roundToInt())) },
+        onCommit = {},
+    )
+
+    AdjustableSlider(
+        label = stringResource(R.string.fade_distance),
+        valueText = "${fade.fadeDistance}%",
+        value = fade.fadeDistance.toFloat(),
+        valueRange = 0f..100f,
+        step = 5f,
+        onValueChange = { onSelect(fade.copy(fadeDistance = it.roundToInt())) },
+        onCommit = {},
+    )
+
+    AdjustableSlider(
+        label = stringResource(R.string.opacity),
+        valueText = "${(fade.opacity * 100).roundToInt()}%",
+        value = fade.opacity,
+        valueRange = 0f..1f,
+        step = 0.05f,
+        onValueChange = { onSelect(fade.copy(opacity = it)) },
+        onCommit = {},
+    )
+
+    AppColorFallbackRow(
+        fallback = fade.appColorSpec.fallback,
+        onSelect = { onSelect(fade.copy(appColorSpec = fade.appColorSpec.copy(fallback = it))) },
+    )
+
+    Text(
+        text = stringResource(R.string.fade_base_color),
+        style = MaterialTheme.typography.titleSmall,
+    )
+    ColorSpecPicker(
+        spec = fade.baseColor,
+        onChange = { onSelect(fade.copy(baseColor = it)) },
+        allowAppIcon = false,
+    )
 }
 
 /** A gradient preview strip, start/end colour pickers and a direction selector. */
@@ -232,30 +289,29 @@ private fun GradientControls(
     gradient: CutoutFill.Gradient,
     onSelect: (CutoutFill) -> Unit,
 ) {
-    // Live preview of the gradient
+    val baseColor = gradient.resolveBaseColor()
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .height(56.dp)
             .clip(RoundedCornerShape(16.dp))
+            .background(baseColor)
             .background(gradient.resolveBrush()),
     )
 
-    // Start colour
     Text(text = stringResource(R.string.gradient_start), style = MaterialTheme.typography.titleSmall)
     ColorSpecPicker(
         spec = gradient.start,
         onChange = { onSelect(gradient.copy(start = it)) },
+        allowAppIcon = false,
     )
-
-    // End colour
     Text(text = stringResource(R.string.gradient_end), style = MaterialTheme.typography.titleSmall)
     ColorSpecPicker(
         spec = gradient.end,
         onChange = { onSelect(gradient.copy(end = it)) },
+        allowAppIcon = false,
     )
 
-    // Direction
     Text(
         text = stringResource(R.string.gradient_direction),
         style = MaterialTheme.typography.titleSmall,
@@ -270,44 +326,39 @@ private fun GradientControls(
         onSelect = { onSelect(gradient.copy(direction = GradientDirection.entries[it])) },
         modifier = Modifier.fillMaxWidth(),
     )
+
+    AdjustableSlider(
+        label = stringResource(R.string.opacity),
+        valueText = "${(gradient.opacity * 100).roundToInt()}%",
+        value = gradient.opacity,
+        valueRange = 0f..1f,
+        step = 0.05f,
+        onValueChange = { onSelect(gradient.copy(opacity = it)) },
+        onCommit = {},
+    )
 }
 
 /**
- * Editor for a single [ColorSpec]: a swatch row (three Material You dynamic roles, a custom wheel
- * pick, then the neutral and accent presets) plus an opacity slider. Selecting a swatch keeps the
- * current opacity, so colour and transparency can be set independently.
+ * Editor for a single [ColorSpec]: a swatch row (App Icon, dynamic roles, custom wheel, presets)
+ * plus an opacity slider and optional fallback selector.
  */
 @Composable
 private fun ColorSpecPicker(
     spec: ColorSpec,
     onChange: (ColorSpec) -> Unit,
+    allowAppIcon: Boolean = true,
 ) {
     var showPicker by remember { mutableStateOf(false) }
     val opacity = spec.opacity
     val fixedRgb = (spec as? ColorSpec.Fixed)?.argb?.and(0xFFFFFFL)
-    val customRgb = fixedRgb?.takeIf { rgb -> PRESET_ARGBS.none { it and 0xFFFFFFL == rgb } }
-
-    val context = LocalContext.current
-    val scope = rememberCoroutineScope()
-    val recentColorPreferences = remember(context) { RecentColorPreferences(context) }
-    val storedRecents by recentColorPreferences.recentColors
-        .collectAsStateWithLifecycle(initialValue = emptyList())
-    // Compared on RGB only, like the presets below: opacity lives on the spec, not the swatch, so a
-    // recent pick and a preset of the same hue are the same swatch here.
-    val recentRgbs = storedRecents
-        .map { it and 0xFFFFFFL }
-        .filterNot { rgb -> PRESET_ARGBS.any { it and 0xFFFFFFL == rgb } }
-    // Derived from the fill itself (OLED black == a fully-black fixed colour), not held as separate
-    // local state: the normal and expanded tabs share this composable slot and only swap the [spec]
-    // passed in, so a remembered flag would leak the toggle across both. Deriving keeps them
-    // independent — each tab reflects its own fill.
+    val customRgb = fixedRgb?.takeIf { rgb -> PresetArgbs.none { it and 0xFFFFFFL == rgb } }
     val isOledBlack = fixedRgb == 0x000000L
 
     fun pickFixed(argb: Long) = onChange(ColorSpec.Fixed(argb).withOpacity(opacity))
     fun pickDynamic(role: DynamicRole) = onChange(ColorSpec.Dynamic(role, opacity))
 
     fun toggleOledBlack(enabled: Boolean) {
-        if (enabled) pickFixed(0xFF000000) else pickDynamic(DynamicRole.PRIMARY)
+        if (enabled) pickFixed(OledBlackArgb) else pickDynamic(DynamicRole.PRIMARY)
     }
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -316,52 +367,53 @@ private fun ColorSpecPicker(
             title = stringResource(R.string.bgColor_oled_title),
             description = stringResource(R.string.bgColor_oled_desc),
             checked = isOledBlack,
-            onCheckedChange = ::toggleOledBlack
+            onCheckedChange = ::toggleOledBlack,
         )
 
         AnimatedVisibility(visible = !isOledBlack) {
             Column(
                 modifier = Modifier.padding(4.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
+                verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 SwatchRow {
-                    // Material you coolors
+                    if (allowAppIcon) {
+                        ColorSwatch(
+                            color = MaterialTheme.colorScheme.surfaceVariant,
+                            selected = spec is ColorSpec.AppIcon,
+                            badgePainter = painterResource(R.drawable.ic_play_store),
+                            badgeDescription = stringResource(R.string.cd_color_app_icon),
+                            onClick = {
+                                val currentFallback = (spec as? ColorSpec.AppIcon)?.fallback ?: AppColorFallback.ADAPTIVE
+                                onChange(ColorSpec.AppIcon(currentFallback, alpha = opacity))
+                            },
+                        )
+                    }
+
                     DynamicSwatch(
                         DynamicRole.PRIMARY,
                         R.string.cd_color_dynamic_primary,
                         spec,
-                        ::pickDynamic
+                        ::pickDynamic,
                     )
                     DynamicSwatch(
                         DynamicRole.SECONDARY,
                         R.string.cd_color_dynamic_secondary,
                         spec,
-                        ::pickDynamic
+                        ::pickDynamic,
                     )
                     DynamicSwatch(
                         DynamicRole.TERTIARY,
                         R.string.cd_color_dynamic_tertiary,
                         spec,
-                        ::pickDynamic
+                        ::pickDynamic,
                     )
 
-                    // Custom wheel pick.
                     CustomColorSwatch(
                         selectedColor = customRgb?.let { Color(0xFF000000L or it) },
                         onClick = { showPicker = true },
                     )
 
-                    // The user's own recent picks, newest first.
-                    recentRgbs.forEach { rgb ->
-                        ColorSwatch(
-                            color = Color(0xFF000000L or rgb),
-                            selected = fixedRgb == rgb,
-                            onClick = { pickFixed(0xFF000000L or rgb) },
-                        )
-                    }
-
-                    // Neutrals then accents, matched on RGB so opacity changes don't drop the selection.
-                    (NEUTRAL_COLORS.map { it.first } + ACCENT_COLORS).forEach { argb ->
+                    (NeutralColors.map { it.first } + AccentColors).forEach { argb ->
                         ColorSwatch(
                             color = Color(argb),
                             selected = spec is ColorSpec.Fixed && spec.argb and 0xFFFFFFL == argb and 0xFFFFFFL,
@@ -369,6 +421,26 @@ private fun ColorSpecPicker(
                         )
                     }
                 }
+
+                AnimatedVisibility(visible = allowAppIcon && spec is ColorSpec.AppIcon) {
+                    val fallback = (spec as? ColorSpec.AppIcon)?.fallback ?: AppColorFallback.ADAPTIVE
+                    AppColorFallbackRow(
+                        fallback = fallback,
+                        onSelect = { onChange(ColorSpec.AppIcon(it, alpha = opacity)) },
+                    )
+                }
+
+                val tooltipText = when {
+                    spec is ColorSpec.AppIcon -> stringResource(R.string.tooltip_app_icon)
+                    spec is ColorSpec.Dynamic && spec.role == DynamicRole.PRIMARY -> stringResource(R.string.tooltip_dynamic_primary)
+                    spec is ColorSpec.Dynamic && spec.role == DynamicRole.SECONDARY -> stringResource(R.string.tooltip_dynamic_secondary)
+                    spec is ColorSpec.Dynamic && spec.role == DynamicRole.TERTIARY -> stringResource(R.string.tooltip_dynamic_tertiary)
+                    spec is ColorSpec.Fixed && (spec.argb and 0xFFFFFFL == 0x000000L) -> stringResource(R.string.tooltip_oled_black)
+                    spec is ColorSpec.Fixed && customRgb != null -> stringResource(R.string.tooltip_custom_color)
+                    spec is ColorSpec.Fixed -> stringResource(R.string.tooltip_preset_color)
+                    else -> null
+                }
+                ColorSelectionTooltip(text = tooltipText)
 
                 AdjustableSlider(
                     label = stringResource(R.string.opacity),
@@ -388,9 +460,7 @@ private fun ColorSpecPicker(
             initial = customRgb?.let { Color(0xFF000000L or it) } ?: Color.White,
             onConfirm = { picked ->
                 showPicker = false
-                val argb = picked.toArgb().toLong() and 0xFFFFFFFFL
-                pickFixed(argb)
-                scope.launch { recentColorPreferences.record(argb) }
+                pickFixed(picked.toArgb().toLong() and 0xFFFFFFFFL)
             },
             onDismiss = { showPicker = false },
         )

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/AppearanceScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/AppearanceScreen.kt
@@ -172,6 +172,14 @@ internal fun AppearanceScreen(
             }
         }
 
+        ColorPickerCard(
+            label = stringResource(R.string.appearance_text_color),
+            selected = appearance.textColor,
+            onSelect = viewModel::setTextColor,
+            defaultLabel = stringResource(R.string.appearance_text_color_auto),
+            allowAppIcon = true,
+        )
+
         // Opens the dedicated screen for the collapsed/expanded background fills (solid colours
         // and gradients, one per state).
         BackgroundCard(onClick = {

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/AppearanceScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/AppearanceScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -67,6 +68,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -77,6 +79,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.view.HapticFeedbackConstantsCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ekoehler.expressivecutout.R
+import com.ekoehler.expressivecutout.core.IslandPreviewBus
 import com.ekoehler.expressivecutout.data.AppearanceSettings
 import com.ekoehler.expressivecutout.data.CutoutColor
 import com.ekoehler.expressivecutout.data.DynamicRole
@@ -98,6 +101,11 @@ internal fun AppearanceScreen(
     val haptics = LocalHapticFeedback.current
     val appearance by viewModel.appearance.collectAsStateWithLifecycle()
     var strokeWidth by remember(appearance.strokeWidthDp) { mutableStateOf(appearance.strokeWidthDp.toFloat()) }
+    var strokeOpacity by remember(appearance.strokeOpacity) { mutableStateOf(appearance.strokeOpacity) }
+
+    LaunchedEffect(Unit) {
+        IslandPreviewBus.setExpandedPreview(false)
+    }
 
     Column(
         modifier = Modifier
@@ -123,29 +131,45 @@ internal fun AppearanceScreen(
         )
 
         AnimatedVisibility(visible = appearance.strokeEnabled) {
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(24.dp),
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-            ) {
-                Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)) {
-                    AdjustableSlider(
-                        label = stringResource(R.string.appearance_stroke_width),
-                        valueText = "${strokeWidth.roundToInt()} dp",
-                        value = strokeWidth,
-                        valueRange = AppearanceSettings.MIN_STROKE_WIDTH_DP.toFloat()..
-                            AppearanceSettings.MAX_STROKE_WIDTH_DP.toFloat(),
-                        step = 1f,
-                        onValueChange = { strokeWidth = it },
-                        onCommit = { viewModel.setStrokeWidth(strokeWidth.roundToInt()) },
-                    )
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(24.dp),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        AdjustableSlider(
+                            label = stringResource(R.string.appearance_stroke_width),
+                            valueText = "${strokeWidth.roundToInt()} dp",
+                            value = strokeWidth,
+                            valueRange = AppearanceSettings.MIN_STROKE_WIDTH_DP.toFloat()..
+                                AppearanceSettings.MAX_STROKE_WIDTH_DP.toFloat(),
+                            step = 1f,
+                            onValueChange = { strokeWidth = it },
+                            onCommit = { viewModel.setStrokeWidth(strokeWidth.roundToInt()) },
+                        )
+
+                        AdjustableSlider(
+                            label = stringResource(R.string.appearance_stroke_opacity),
+                            valueText = "${(strokeOpacity * 100).roundToInt()}%",
+                            value = strokeOpacity,
+                            valueRange = 0f..1f,
+                            step = 0.05f,
+                            onValueChange = { strokeOpacity = it },
+                            onCommit = { viewModel.setStrokeOpacity(strokeOpacity) },
+                        )
+                    }
                 }
+                ColorPickerCard(
+                    label = stringResource(R.string.appearance_stroke_color),
+                    selected = appearance.strokeColor,
+                    onSelect = { it?.let(viewModel::setStrokeColor) },
+                    allowAppIcon = true,
+                )
             }
-            ColorPickerCard(
-                label = stringResource(R.string.appearance_stroke_color),
-                selected = appearance.strokeColor,
-                onSelect = { it?.let(viewModel::setStrokeColor) },
-            )
         }
 
         // Opens the dedicated screen for the collapsed/expanded background fills (solid colours
@@ -266,6 +290,7 @@ internal fun ColorSwatch(
     selected: Boolean,
     onClick: () -> Unit,
     badge: androidx.compose.ui.graphics.vector.ImageVector? = null,
+    badgePainter: androidx.compose.ui.graphics.painter.Painter? = null,
     badgeDescription: String? = null,
 ) {
     val ring = MaterialTheme.colorScheme.primary
@@ -298,7 +323,14 @@ internal fun ColorSwatch(
     ) {
         // Contrast the marks against the swatch itself.
         val markColor = if (color.luminance() > 0.5f) Color(0xFF0A0A0A) else Color.White
-        if (badge != null) {
+        if (badgePainter != null) {
+            Icon(
+                painter = badgePainter,
+                contentDescription = badgeDescription,
+                tint = Color.Unspecified,
+                modifier = Modifier.size(20.dp),
+            )
+        } else if (badge != null) {
             Icon(
                 imageVector = badge,
                 contentDescription = badgeDescription,

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/DynamicTilesScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/DynamicTilesScreen.kt
@@ -114,7 +114,7 @@ private fun DynamicTileCard(
         badgeColor = containerColor.resolve()
         glyphColor = when (containerColor) {
             is CutoutColor.Dynamic -> onDynamicRole(containerColor.role)
-            is CutoutColor.Solid -> if (badgeColor.luminance() > 0.5f) Color(0xFF0A0A0A) else Color.White
+            is CutoutColor.Solid, is CutoutColor.AppIcon -> if (badgeColor.luminance() > 0.5f) Color(0xFF0A0A0A) else Color.White
         }
     } else {
         badgeColor = accent.copy(alpha = 0.18f)

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/ShowsWhenEmptyScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/ShowsWhenEmptyScreen.kt
@@ -78,6 +78,7 @@ import com.ekoehler.expressivecutout.overlay.CenterShortcutCatalog
 import com.ekoehler.expressivecutout.overlay.MaterialIconCatalog
 import com.ekoehler.expressivecutout.overlay.loadImageBitmapOrNull
 import com.ekoehler.expressivecutout.overlay.resolve
+import com.ekoehler.expressivecutout.ui.components.ColorPickerCard
 import com.ekoehler.expressivecutout.ui.AppViewModel
 import com.ekoehler.expressivecutout.ui.components.ColorPickerCard
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/SizePositionScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingScreens/SizePositionScreen.kt
@@ -121,6 +121,7 @@ internal fun SizePositionScreen(
             IslandPreviewBus.setExpandedPreview(false)
         }
     }
+    // Mirror which tab is being edited (collapsed vs expanded) in the pinned live preview.
     LaunchedEffect(tab) { IslandPreviewBus.setExpandedPreview(tab == 1) }
 
     Column(

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingsTab.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/SettingsTab.kt
@@ -42,6 +42,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,9 +53,13 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.view.HapticFeedbackConstantsCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ekoehler.expressivecutout.R
 import com.ekoehler.expressivecutout.core.DynamicTile
+import com.ekoehler.expressivecutout.core.IslandPreviewBus
 import com.ekoehler.expressivecutout.core.SystemEventType
 import com.ekoehler.expressivecutout.permissions.Permissions
 import com.ekoehler.expressivecutout.ui.AppViewModel
@@ -97,6 +102,38 @@ fun SettingsTab(
     onOpenShizuku: () -> Unit,
     onOpenPermissionDot: () -> Unit,
 ) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val isPreviewRoute = route == SettingsRoute.SizePosition ||
+        route == SettingsRoute.Appearance ||
+        route == SettingsRoute.Background
+
+    DisposableEffect(lifecycleOwner, isPreviewRoute) {
+        fun refresh() {
+            if (isPreviewRoute) {
+                IslandPreviewBus.setActive(Permissions.isAccessibilityGranted(context))
+            } else {
+                IslandPreviewBus.setActive(false)
+                IslandPreviewBus.setExpandedPreview(false)
+            }
+        }
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> refresh()
+                Lifecycle.Event.ON_PAUSE -> IslandPreviewBus.setActive(false)
+                else -> Unit
+            }
+        }
+        refresh()
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            if (isPreviewRoute) {
+                IslandPreviewBus.setActive(false)
+                IslandPreviewBus.setExpandedPreview(false)
+            }
+        }
+    }
     // Routing (and back navigation, via the bottom bar) is owned by MainScreen.
     // Deeper routes slide in from the right; stepping back slides in from the left, so the
     // motion mirrors the predictive-back peek.

--- a/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/tiles/MusicTileScreen.kt
+++ b/app/src/main/java/com/ekoehler/expressivecutout/ui/screen/tiles/MusicTileScreen.kt
@@ -42,8 +42,8 @@ import com.ekoehler.expressivecutout.R
 import com.ekoehler.expressivecutout.data.MusicButtonStyle
 import com.ekoehler.expressivecutout.overlay.resolve
 import com.ekoehler.expressivecutout.ui.AppViewModel
-import com.ekoehler.expressivecutout.ui.screen.AdjustableSlider
 import com.ekoehler.expressivecutout.ui.components.ColorPickerCard
+import com.ekoehler.expressivecutout.ui.screen.AdjustableSlider
 import com.ekoehler.expressivecutout.ui.screen.SettingsToggleCard
 import kotlin.math.roundToInt
 

--- a/app/src/main/res/drawable/ic_play_store.xml
+++ b/app/src/main/res/drawable/ic_play_store.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#4285F4"
+        android:pathData="M3.61,1.81L13.89,12.09L3.61,22.37C3.24,21.99 3,21.43 3,20.76V3.42C3,2.75 3.24,2.19 3.61,1.81Z"/>
+    <path
+        android:fillColor="#EA4335"
+        android:pathData="M17.37,8.61L13.89,12.09L3.61,1.81C3.96,1.46 4.54,1.25 5.25,1.65L17.37,8.61Z"/>
+    <path
+        android:fillColor="#FBBC04"
+        android:pathData="M21.13,10.77C21.91,11.22 21.91,12.96 21.13,13.41L17.37,15.57L13.89,12.09L17.37,8.61L21.13,10.77Z"/>
+    <path
+        android:fillColor="#34A853"
+        android:pathData="M17.37,15.57L5.25,22.53C4.54,22.93 3.96,22.72 3.61,22.37L13.89,12.09L17.37,15.57Z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,10 +188,12 @@
     <string name="appearance_stroke_title">Stroke</string>
     <string name="appearance_stroke_desc">Draw an outline around the island.</string>
     <string name="appearance_stroke_width">Stroke width</string>
+    <string name="appearance_stroke_opacity">Stroke opacity</string>
     <string name="appearance_stroke_color">Stroke colour</string>
     <string name="appearance_background_color">Background colour</string>
     <string name="appearance_send_color">Send button colour</string>
     <string name="appearance_cancel_color">Cancel button colour</string>
+    <string name="cd_color_app_icon">App icon colour</string>
     <string name="cd_color_dynamic">Material You dynamic colour</string>
     <string name="cd_color_default_accent">Match notification colour</string>
     <string name="cd_color_default_neutral">Default neutral colour</string>
@@ -238,10 +240,33 @@
     <string name="perm_shizuku_title">Shizuku</string>
     <string name="perm_shizuku_desc">Optional. Only needed to hide the status bar notification icons.</string>
 
+    <string name="app_color_fallback_title">Non-app event fallback</string>
+    <string name="app_color_fallback_desc">Fallback colour when no app notification is active</string>
+    <string name="app_color_fallback_dynamic">Material You</string>
+    <string name="app_color_fallback_oled">OLED Black</string>
+    <string name="app_color_fallback_adaptive">Adaptive</string>
+
+    <string name="tooltip_dynamic_primary">Material You (Primary) — Dynamic accent adapting to your wallpaper and Android theme.</string>
+    <string name="tooltip_dynamic_secondary">Material You (Secondary) — Subtle tonal dynamic accent matching your wallpaper.</string>
+    <string name="tooltip_dynamic_tertiary">Material You (Tertiary) — Playful dynamic accent color derived from your theme.</string>
+    <string name="tooltip_app_icon">App Icon Adaptive Colour — Dynamically extracts the primary branding colour from the notifying app\'s default launcher icon.</string>
+    <string name="tooltip_oled_black">Pure Black (#000000) — Turns off pixels on OLED displays for maximum battery efficiency and stealth.</string>
+    <string name="tooltip_custom_color">Custom Colour — Uses your chosen color across all events.</string>
+    <string name="tooltip_preset_color">Preset Colour — Uses this fixed accent across all events.</string>
+    <string name="tooltip_default_reset">Default Island Accent — Restores the built-in default theme colour.</string>
+
     <!-- Background screen -->
     <string name="settings_background_subtitle">Separate colours or gradients for the normal and expanded cutout</string>
     <string name="label_solid">Solid</string>
     <string name="label_gradient">Gradient</string>
+    <string name="label_app_fade">App Fade</string>
+    <string name="fade_direction">Fade direction</string>
+    <string name="fade_left_to_right">Left to right</string>
+    <string name="fade_right_to_left">Right to left</string>
+    <string name="fade_gradient_distance">Gradient distance</string>
+    <string name="fade_distance">Fade distance</string>
+    <string name="fade_solid_length">Gradient distance</string>
+    <string name="fade_base_color">Fade target colour</string>
     <string name="gradient_start">Start colour</string>
     <string name="gradient_end">End colour</string>
     <string name="gradient_direction">Direction</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,8 +242,8 @@
     <string name="perm_shizuku_title">Shizuku</string>
     <string name="perm_shizuku_desc">Optional. Only needed to hide the status bar notification icons.</string>
 
-    <string name="app_color_fallback_title">Non-app event fallback</string>
-    <string name="app_color_fallback_desc">Fallback colour when no app notification is active</string>
+    <string name="app_color_fallback_title">Fallback colour</string>
+    <string name="app_color_fallback_desc">Used when no app icon is available (such as system events or an idle island)</string>
     <string name="app_color_fallback_dynamic">Material You</string>
     <string name="app_color_fallback_oled">OLED Black</string>
     <string name="app_color_fallback_adaptive">Adaptive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -190,6 +190,8 @@
     <string name="appearance_stroke_width">Stroke width</string>
     <string name="appearance_stroke_opacity">Stroke opacity</string>
     <string name="appearance_stroke_color">Stroke colour</string>
+    <string name="appearance_text_color">Text colour</string>
+    <string name="appearance_text_color_auto">Auto (contrast)</string>
     <string name="appearance_background_color">Background colour</string>
     <string name="appearance_send_color">Send button colour</string>
     <string name="appearance_cancel_color">Cancel button colour</string>

--- a/app/src/test/java/com/ekoehler/expressivecutout/overlay/CutoutColorsTest.kt
+++ b/app/src/test/java/com/ekoehler/expressivecutout/overlay/CutoutColorsTest.kt
@@ -1,0 +1,124 @@
+package com.ekoehler.expressivecutout.overlay
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.ui.graphics.Color
+import com.ekoehler.expressivecutout.core.SystemEventType
+import com.ekoehler.expressivecutout.data.AppColorFallback
+import com.ekoehler.expressivecutout.data.ColorSpec
+import com.ekoehler.expressivecutout.data.CutoutColor
+import com.ekoehler.expressivecutout.data.DynamicRole
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CutoutColorsTest {
+
+    @Test
+    fun testSystemEventPrimaryColorDefault() {
+        val wifiEvent = IslandEvent(
+            id = 1L,
+            icon = IslandIcon.Vector(Icons.Rounded.Info),
+            label = "Wi-Fi Disconnected",
+            accent = Color(SystemEventType.WIFI_DISCONNECTED.accent),
+        )
+
+        val primary = wifiEvent.resolvePrimaryColor()
+        assertEquals(Color(SystemEventType.WIFI_DISCONNECTED.accent), primary)
+
+        // When stroke is configured as AppIcon, it resolves to the event's primary accent
+        val strokeColor = CutoutColor.AppIcon(AppColorFallback.ADAPTIVE)
+        val resolvedStroke = strokeColor.resolveColor(appColor = primary)
+        assertEquals(Color(SystemEventType.WIFI_DISCONNECTED.accent), resolvedStroke)
+
+        // When background is configured as AppIcon, it also resolves to the event's primary accent
+        val bgSpec = ColorSpec.AppIcon(AppColorFallback.ADAPTIVE)
+        val resolvedBg = bgSpec.resolveColor(appColor = primary)
+        assertEquals(Color(SystemEventType.WIFI_DISCONNECTED.accent), resolvedBg)
+    }
+
+    @Test
+    fun testSystemEventPrimaryColorWithColorOverride() {
+        val overrideColor = CutoutColor.Solid(0xFFFF0000)
+        val chargingEvent = IslandEvent(
+            id = 2L,
+            icon = IslandIcon.Vector(Icons.Rounded.Info),
+            label = "Charging",
+            accent = Color(SystemEventType.CHARGING_STARTED.accent),
+            colorOverride = overrideColor,
+        )
+
+        val primary = chargingEvent.resolvePrimaryColor()
+        assertEquals(Color(0xFFFF0000), primary)
+
+        val strokeColor = CutoutColor.AppIcon(AppColorFallback.ADAPTIVE)
+        val resolvedStroke = strokeColor.resolveColor(appColor = primary)
+        assertEquals(Color(0xFFFF0000), resolvedStroke)
+    }
+
+    @Test
+    fun testSystemEventPrimaryColorWithDynamicTheme() {
+        val mockDynamicPrimary = Color(0xFF123456)
+        val mockDynamicSecondary = Color(0xFF654321)
+
+        val dynamicResolver: (DynamicRole) -> Color = { role ->
+            when (role) {
+                DynamicRole.PRIMARY -> mockDynamicPrimary
+                DynamicRole.SECONDARY -> mockDynamicSecondary
+                DynamicRole.TERTIARY -> Color(0xFF999999)
+            }
+        }
+
+        val dynamicEvent = IslandEvent(
+            id = 3L,
+            icon = IslandIcon.Vector(Icons.Rounded.Info),
+            label = "Wi-Fi Connected",
+            accent = Color(SystemEventType.WIFI_CONNECTED.accent),
+            useThemeColor = true,
+            themeColorRole = DynamicRole.PRIMARY,
+        )
+
+        val primary = dynamicEvent.resolvePrimaryColor(dynamicResolver)
+        assertEquals(mockDynamicPrimary, primary)
+
+        val strokeColor = CutoutColor.AppIcon(AppColorFallback.ADAPTIVE)
+        val resolvedStroke = strokeColor.resolveColor(appColor = primary, dynamicResolver = dynamicResolver)
+        assertEquals(mockDynamicPrimary, resolvedStroke)
+    }
+
+    @Test
+    fun testNotificationWithAppColor() {
+        val appColor = Color(0xFF00FF00)
+        val notificationEvent = IslandEvent(
+            id = 4L,
+            icon = IslandIcon.Vector(Icons.Rounded.Info),
+            label = "WhatsApp",
+            accent = Color(0xFF38BDF8),
+            appColor = appColor,
+        )
+
+        val primary = notificationEvent.resolvePrimaryColor()
+        assertEquals(appColor, primary)
+
+        val strokeColor = CutoutColor.AppIcon(AppColorFallback.ADAPTIVE)
+        val resolvedStroke = strokeColor.resolveColor(appColor = primary)
+        assertEquals(appColor, resolvedStroke)
+    }
+
+    @Test
+    fun testEmptyIslandFallbackStrategies() {
+        val mockDynamic = Color(0xFF112233)
+        val dynamicResolver: (DynamicRole) -> Color = { mockDynamic }
+
+        // When no event is active, appColor is null
+        val appColor: Color? = null
+
+        val adaptiveColor = CutoutColor.AppIcon(AppColorFallback.ADAPTIVE)
+        assertEquals(mockDynamic, adaptiveColor.resolveColor(appColor = appColor, dynamicResolver = dynamicResolver))
+
+        val dynamicFallback = CutoutColor.AppIcon(AppColorFallback.DYNAMIC_THEME)
+        assertEquals(mockDynamic, dynamicFallback.resolveColor(appColor = appColor, dynamicResolver = dynamicResolver))
+
+        val oledFallback = CutoutColor.AppIcon(AppColorFallback.OLED_BLACK)
+        assertEquals(Color(0xFF000000L), oledFallback.resolveColor(appColor = appColor, dynamicResolver = dynamicResolver))
+    }
+}

--- a/app/src/test/java/com/ekoehler/expressivecutout/overlay/CutoutColorsTest.kt
+++ b/app/src/test/java/com/ekoehler/expressivecutout/overlay/CutoutColorsTest.kt
@@ -7,8 +7,11 @@ import com.ekoehler.expressivecutout.core.SystemEventType
 import com.ekoehler.expressivecutout.data.AppColorFallback
 import com.ekoehler.expressivecutout.data.ColorSpec
 import com.ekoehler.expressivecutout.data.CutoutColor
+import com.ekoehler.expressivecutout.data.CutoutFill
 import com.ekoehler.expressivecutout.data.DynamicRole
+import com.ekoehler.expressivecutout.data.GradientDirection
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CutoutColorsTest {
@@ -120,5 +123,34 @@ class CutoutColorsTest {
 
         val oledFallback = CutoutColor.AppIcon(AppColorFallback.OLED_BLACK)
         assertEquals(Color(0xFF000000L), oledFallback.resolveColor(appColor = appColor, dynamicResolver = dynamicResolver))
+    }
+
+    @Test
+    fun testGradientWithAppIconSerialization() {
+        val gradient = CutoutFill.Gradient(
+            start = ColorSpec.AppIcon(AppColorFallback.ADAPTIVE),
+            end = ColorSpec.Fixed(0xFF000000L),
+            direction = GradientDirection.HORIZONTAL,
+            opacity = 0.8f,
+        )
+        val serialized = gradient.serialize()
+        val deserialized = CutoutFill.deserialize(serialized) as? CutoutFill.Gradient
+
+        assertEquals(gradient.start, deserialized?.start)
+        assertEquals(gradient.end, deserialized?.end)
+        assertEquals(gradient.direction, deserialized?.direction)
+        assertEquals(0.8f, deserialized?.opacity ?: 0f, 0.001f)
+    }
+
+    @Test
+    fun testLegacyAppFadeMigration() {
+        val legacySerialized = "app_fade|app_icon:ADAPTIVE:1.0|4278190080:1.0|LEFT_TO_RIGHT|30|20|1.0"
+        val deserialized = CutoutFill.deserialize(legacySerialized)
+
+        assertTrue(deserialized is CutoutFill.Gradient)
+        val grad = deserialized as CutoutFill.Gradient
+        assertTrue(grad.start is ColorSpec.AppIcon)
+        assertEquals(GradientDirection.HORIZONTAL, grad.direction)
+        assertEquals(1.0f, grad.opacity, 0.001f)
     }
 }


### PR DESCRIPTION
Resolves #22 (https://github.com/EvanKoe/expressive-cutout/issues/22)

## Summary

This PR adds comprehensive stroke and background color customization for the Dynamic Island in both collapsed (**Normal**) and **Expanded** states, including **App-Adaptive** color extraction for notifications and full **Event-Adaptive** color support for system events (Wi-Fi, Charging, Lock/Unlock, Battery, etc.).

---

## What Was Done

### 1. Stroke Outline Customization
- Added an outline/stroke toggle for the island with adjustable **Stroke width** (1–8 dp) and **Stroke opacity** (0–100%).
- Added **Stroke colour** selection with presets, custom color picker, Material You dynamic theme roles, and **App Icon Adaptive Colour**.
- For App Icon adaptive color, added **Non-app event fallback** strategies:
  - **Adaptive**: Uses the active event's primary accent or media art color.
  - **Material You**: Uses the system dynamic theme accent.
  - **OLED Black**: Uses pure black (`#000000`).

### 2. Collapsed & Expanded Background Customization
- Dedicated background fill configurations for **Normal (collapsed)** and **Expanded** states with smooth cross-fade animation during expansion/collapse.
- Three background modes:
  - **Solid**: Flat fill supporting fixed colors, Material You dynamic roles, OLED black, and App Icon adaptive color.
  - **Gradient**: Two-stop gradient with selectable direction (**Horizontal**, **Vertical**, **Diagonal**), start/end colors, and opacity.
  - **App Fade**: Directional fade (**Left to right** / **Right to left**) from the notifying app/event primary branding color into a base color (e.g. OLED black), with adjustable solid percentage, fade distance, and opacity.

### 3. Custom System Events Support (Wi-Fi, Charging, Lock/Unlock, etc.)
- Added unified primary color resolution for all events via `IslandEvent.primaryColor()`.
- Primary color resolution follows a consistent hierarchy:
  1. Per-event user color override (`colorOverride`)
  2. Material You dynamic color when *Dynamic color for all events* (`useThemeColor`) is enabled
  3. Extracted app launcher icon color (`appColor`) for notifications
  4. Built-in event default accent (`accent`) for system events (Wi-Fi, USB, Charging, Battery, Headphones, etc.)
- Stroke and background configurations (including App Fade and App Icon adaptive stroke/background) are now applied to system events just like notifications, deriving the color from the event's primary color or dynamic theme.

### 4. Unit Testing & Verification
- Added JVM unit tests in `CutoutColorsTest` verifying color resolution for system events, color overrides, dynamic themes, app notifications, and empty/idle fallbacks.

---

## Screenshots

| Appearance & Stroke Settings | Background (Normal State) |
|:---:|:---:|
| ![Appearance Stroke](https://github.com/user-attachments/assets/5e3698e2-0d67-4eab-a95f-3f6abe8b7c7a) | ![Background Normal](https://github.com/user-attachments/assets/965b00f4-33c5-4a55-881b-9d6878d6f83c) |

| Background (Expanded State) | Background App Fade Settings |
|:---:|:---:|
| ![Background Expanded](https://github.com/user-attachments/assets/c84e7c96-aa83-43f1-a3be-972eaa1b0c51) | ![Background App Fade](https://github.com/user-attachments/assets/bf97ed45-1ee2-46e1-98d7-9eba6e5c86bd) |

---

## Technical Details

- **`AppIconColorExtractor`**: Extracts dominant/vibrant branding color from the application's default launcher icon with fallback.
- **`AppearancePreferences`**: Stores stroke settings and serialized `CutoutFill` (Solid, Gradient, AppFade) and `CutoutColor` preferences via DataStore.
- **`CutoutColors`**: Color resolver supporting opacity, dynamic Material You roles, fallback strategies, and `IslandEvent.primaryColor()`.
- **`DynamicIsland` & `IslandSurface`**: Renders stroke border and interpolates background brushes and base colors between normal and expanded states.
- **`BackgroundScreen` & `AppearanceScreen`**: Settings UI with preview integration, sliders, and fallback selection.
